### PR TITLE
Account update leaf 4559 - Test Scenario #1

### DIFF
--- a/end2end/tests/acctUpdate.spec.ts
+++ b/end2end/tests/acctUpdate.spec.ts
@@ -4,7 +4,7 @@ test.use({
   ignoreHTTPSErrors: true
 });
 
-test.only('test', async ({ page }) => {
+test('noGroupsOrPositions', async ({ page }, testInfo) => {
     
     await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');
   //Open the New Account Update Page
@@ -33,16 +33,16 @@ test.only('test', async ({ page }) => {
 const OldRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(0);
 await OldRep.click();
 await OldRep.fill("vtrmvtlynnette");
-//await expect(page.getByText('Old Account Search results')).toBeInViewport();
-//await expect(page.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' })).toBeInViewport();
 await page1.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' }).click();
   
  
 const oldAcct:Locator = page1.getByLabel('Jacobs, Gilbert Wilderman.');
 oldAcct.click();
-//.toContainText('Jacobs, Gilbert Wilderman.vtrmvtlynnette');
 
- 
+
+const screenshot = await page.screenshot()
+await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
 // Enter New Account information
 const newRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(1);
 await newRep.click();
@@ -52,24 +52,44 @@ await newRep.fill("vtrkmwroseann");
 const newAcct:Locator = page1.getByLabel('Greenholt, Shirlene Parisian');
 newAcct.click();
 
+//await expect(page.getByRole('button', { name: 'Preview Changes' })).toBeInViewport();
+
+await expect(page1.getByText('New Account Search results')).toBeVisible();
+
+
 //Click to View Changes
 
-  await page1.getByRole('button', { name: 'Preview Changes' }).click();
+const previewChange:Locator = page1.getByRole('button', {name: 'Preview Changes'});
+await previewChange.hover();
+await previewChange.click ();
+
   
+await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+  
+//Wait for page to refresh (
+
+
   //Veirfy Goups and Positions is empty. 
- await expect (page1.locator('#grid_groups_info')).toContainText('No groups found');
+
+  await expect (page1.locator('#grid_groups_info')).toContainText('No groups found');
 
  await expect (page1.locator('#grid_positions_info')).toContainText('No Positions found');
  
+ await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
 //Accept changes
 await page1.getByRole('button', { name: 'Update Records' }).click();
 
+await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+//await expect(page1.getByText('Syncing has finished. You are')).toBeInViewport();
 //Verify there are not any group/positions updates
 await expect(page1.locator('#groups_no_updates')).toContainText('no updates');
 await expect(page1.locator('#positions_no_updates')).toContainText('no updates');
 
 //No processing errors
 await expect(page.locator('#no_errors')).toContainText('no errors');
+await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
 
 });

--- a/end2end/tests/acctUpdate.spec.ts
+++ b/end2end/tests/acctUpdate.spec.ts
@@ -4,6 +4,7 @@ test.use({
   ignoreHTTPSErrors: true
 });
 
+//Test the old user do not have any groups and positions and everything works correctly
 test('noGroupsOrPositions', async ({ page }, testInfo) => {
     
     await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');

--- a/end2end/tests/acctUpdate.spec.ts
+++ b/end2end/tests/acctUpdate.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, Locator } from '@playwright/test';
+
+test.use({
+  ignoreHTTPSErrors: true
+});
+
+test.only('test', async ({ page }) => {
+    
+    await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');
+  //Open the New Account Update Page
+    await page.getByRole('button', { name: ' New Account Updater' }).click();
+  //Sync the Service forst
+  
+  await page.getByRole('link', { name: 'Sync Services' }).click();
+
+//Wait for the new page to popup
+  const page1Promise = page.waitForEvent('popup');
+  const page1 = await page1Promise;
+
+//Verify the Sync Service was completed
+  await expect(page1.getByText('Syncing has finished. You are')).toBeInViewport();
+
+//Return the the Admin page
+ await page1.getByLabel('admin submenu').click();
+ await page1.getByLabel('admin submenu').click();
+ await page1.getByRole('link', { name: 'Admin Panel' }).click();
+
+//Return to the New Account Update page
+ const acctUpdate:Locator = page1.getByRole('button', { name: ' New Account Updater' });
+ await acctUpdate.click();
+
+ //Identify the Old Account to be disabled
+const OldRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(0);
+await OldRep.click();
+await OldRep.fill("vtrmvtlynnette");
+//await expect(page.getByText('Old Account Search results')).toBeInViewport();
+//await expect(page.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' })).toBeInViewport();
+await page1.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' }).click();
+  
+ 
+const oldAcct:Locator = page1.getByLabel('Jacobs, Gilbert Wilderman.');
+oldAcct.click();
+//.toContainText('Jacobs, Gilbert Wilderman.vtrmvtlynnette');
+
+ 
+// Enter New Account information
+const newRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(1);
+await newRep.click();
+await newRep.fill("vtrkmwroseann");
+ 
+
+const newAcct:Locator = page1.getByLabel('Greenholt, Shirlene Parisian');
+newAcct.click();
+
+//Click to View Changes
+
+  await page1.getByRole('button', { name: 'Preview Changes' }).click();
+  
+  //Veirfy Goups and Positions is empty. 
+ await expect (page1.locator('#grid_groups_info')).toContainText('No groups found');
+
+ await expect (page1.locator('#grid_positions_info')).toContainText('No Positions found');
+ 
+//Accept changes
+await page1.getByRole('button', { name: 'Update Records' }).click();
+
+//Verify there are not any group/positions updates
+await expect(page1.locator('#groups_no_updates')).toContainText('no updates');
+await expect(page1.locator('#positions_no_updates')).toContainText('no updates');
+
+//No processing errors
+await expect(page.locator('#no_errors')).toContainText('no errors');
+
+
+});

--- a/end2end/tests/acctUpdateMultiple.spec.ts
+++ b/end2end/tests/acctUpdateMultiple.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, Locator } from '@playwright/test';
+
+test.use({
+  ignoreHTTPSErrors: true
+});
+
+test.only('oldAcctGroupsAndPosition', async ({ page }) => {
+    
+    await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');
+  //Open the New Account Update Page
+    await page.getByRole('button', { name: ' New Account Updater' }).click();
+  //Sync the Service forst
+  
+  await page.getByRole('link', { name: 'Sync Services' }).click();
+
+//Wait for the new page to popup
+  const page1Promise = page.waitForEvent('popup');
+  const page1 = await page1Promise;
+
+//Verify the Sync Service was completed
+  await expect(page1.getByText('Syncing has finished. You are')).toBeInViewport();
+
+//Return the the Admin page
+ await page1.getByLabel('admin submenu').click();
+ await page1.getByLabel('admin submenu').click();
+ await page1.getByRole('link', { name: 'Admin Panel' }).click();
+
+//Return to the New Account Update page
+ const acctUpdate:Locator = page1.getByRole('button', { name: ' New Account Updater' });
+ await acctUpdate.click();
+
+ //Identify the Old Account to be disabled
+const OldRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(0);
+await OldRep.click();
+await OldRep.fill("vtriujtalisha");
+//await expect(page.getByText('Old Account Search results')).toBeInViewport();
+//await expect(page.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' })).toBeInViewport();
+await page1.getByRole('cell', { name: 'Kozey, Kirstin Schimmel.' }).click();
+  
+ 
+const oldAcct:Locator = page1.getByLabel('Kozey, Kirstin Schimmel.');
+oldAcct.click();
+
+
+ 
+// Enter New Account information
+const newRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(1);
+await newRep.click();
+await newRep.fill("vtrvxhconception");
+ 
+
+const newAcct:Locator = page1.getByLabel('Predovic, Augustine Hammes.');
+newAcct.click();
+
+await expect(page1.getByText('New Account Search results')).toBeVisible();
+
+//Click to View Changes
+const previewChange:Locator = page1.getByRole('button', {name: 'Preview Changes'});
+await previewChange.hover();
+await previewChange.click ();
+
+//Old Account with Groups & Positions
+
+  //Veirfy Goups and Positions is empty have value
+
+  await expect (page1.locator('#grid_groups_info')).toContainText('No groups found');
+
+ await expect (page1.locator('#grid_positions_info')).toContainText('No Positions found');
+ 
+//Accept changes
+await page1.getByRole('button', { name: 'Update Records' }).click();
+
+//await expect(page1.getByText('Syncing has finished. You are')).toBeInViewport();
+//Verify there are not any group/positions updates
+await expect(page1.locator('#groups_no_updates')).toContainText('no updates');
+await expect(page1.locator('#positions_no_updates')).toContainText('no updates');
+
+//No processing errors
+await expect(page.locator('#no_errors')).toContainText('no errors');
+
+
+});

--- a/end2end/tests/acctUpdateMultiple.spec.ts
+++ b/end2end/tests/acctUpdateMultiple.spec.ts
@@ -4,14 +4,17 @@ test.use({
   ignoreHTTPSErrors: true
 });
 
-test.only('oldAcctGroupsAndPosition', async ({ page }) => {
+
+//This test has an user with multiple groups and positions
+test('oldAcctGroupsAndPosition', async ({ page }, testInfo) => {
     
     await page.goto('https://host.docker.internal/Test_Request_Portal/admin/');
-  //Open the New Account Update Page
-    await page.getByRole('button', { name: ' New Account Updater' }).click();
-  //Sync the Service forst
   
-  await page.getByRole('link', { name: 'Sync Services' }).click();
+    //Open the New Account Update Page
+    await page.getByRole('button', { name: ' New Account Updater' }).click();
+  
+    //Sync the Service first
+    await page.getByRole('link', { name: 'Sync Services' }).click();
 
 //Wait for the new page to popup
   const page1Promise = page.waitForEvent('popup');
@@ -32,23 +35,16 @@ test.only('oldAcctGroupsAndPosition', async ({ page }) => {
  //Identify the Old Account to be disabled
 const OldRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(0);
 await OldRep.click();
-await OldRep.fill("vtriujtalisha");
-//await expect(page.getByText('Old Account Search results')).toBeInViewport();
-//await expect(page.getByRole('cell', { name: 'Jacobs, Gilbert Wilderman.' })).toBeInViewport();
-await page1.getByRole('cell', { name: 'Kozey, Kirstin Schimmel.' }).click();
-  
+await OldRep.fill("vtrfaufelecia");
+await page1.getByRole('cell', { name: 'Schultz, Phuong Boyer.' }).click();
  
-const oldAcct:Locator = page1.getByLabel('Kozey, Kirstin Schimmel.');
+const oldAcct:Locator = page1.getByLabel('Schultz, Phuong Boyer.');
 oldAcct.click();
 
-
- 
 // Enter New Account information
 const newRep:Locator = page1.locator('css=input.employeeSelectorInput').nth(1);
 await newRep.click();
 await newRep.fill("vtrvxhconception");
- 
-
 const newAcct:Locator = page1.getByLabel('Predovic, Augustine Hammes.');
 newAcct.click();
 
@@ -59,21 +55,29 @@ const previewChange:Locator = page1.getByRole('button', {name: 'Preview Changes'
 await previewChange.hover();
 await previewChange.click ();
 
-//Old Account with Groups & Positions
+//Old Account with Groups & Positions Veirfy Goups and Positions have value
 
-  //Veirfy Goups and Positions is empty have value
+//Group
+await expect(page1.getByText('Export Group NameCurrent')).toBeVisible();
 
-  await expect (page1.locator('#grid_groups_info')).toContainText('No groups found');
+//Position
+await expect(page1.getByText('Export Position TitleCurrent')).toBeVisible();
 
- await expect (page1.locator('#grid_positions_info')).toContainText('No Positions found');
- 
+// Need screenshot inserted in here
+const screenshot = await page.screenshot();
+await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
 //Accept changes
 await page1.getByRole('button', { name: 'Update Records' }).click();
 
-//await expect(page1.getByText('Syncing has finished. You are')).toBeInViewport();
-//Verify there are not any group/positions updates
-await expect(page1.locator('#groups_no_updates')).toContainText('no updates');
-await expect(page1.locator('#positions_no_updates')).toContainText('no updates');
+//Group - Verify updates
+await expect(page1.locator('#groups_updated')).toContainText('Removed vtrfaufelecia and added vtrvxhconception to Iron Sports (nexus)');
+
+//Positions - Verify updates
+await expect(page1.locator('#positions_updated')).toContainText('Removed vtrfaufelecia and added vtrvxhconception to position: LEAF Coaches');
+await expect(page1.locator('#positions_updated')).toContainText('Removed vtrfaufelecia and added vtrvxhconception to position: Chief of Everything');
+await expect(page1.locator('#positions_updated')).toContainText('Removed vtrfaufelecia and added vtrvxhconception to position: Chief, Facilties');
+await expect(page1.locator('#positions_updated')).toContainText('Removed vtrfaufelecia and added vtrvxhconception to position: Dog Sitter West');
 
 //No processing errors
 await expect(page.locator('#no_errors')).toContainText('no errors');


### PR DESCRIPTION
This is the end2end test to Verify when a user account is disabled and the previous groups and positions are moved to the new account.  This first scenario accounts for when there are not any groups or positions. I am verifying that the process runs smoothly and there are not any groups or positions that are listed and there are not any errors when running this scenario.  Please only review acctUpdate file.
