### PR TITLE
LEAF 4585 test - prevent negative step coords

### DIFF
--- a/API-tests/workflow.go
+++ b/API-tests/workflow.go
@@ -1,0 +1,16 @@
+package main
+
+type WorkflowStep struct {
+	WorkflowID 							int `json:"workflowID"`
+	StepID  							int `json:"stepID"`
+	StepTitle   						string `json:"stepTitle"`
+	StepBgColor 						string `json:"stepBgColor"`
+	StepFontColor   					string `json:"stepFontColor"`
+	JsSrc 								string `json:"jsSrc"`
+	PosX 								int `json:"posX"`
+	PosY 								int `json:"posY"`
+	IndicatorID_for_assigned_empUID 	int `json:"indicatorID_for_assigned_empUID"`
+	IndicatorID_for_assigned_groupID 	int `json:"indicatorID_for_assigned_groupID"`
+	RequiresDigitalSignature 			int `json:"requiresDigitalSignature"`
+	StepData 							string `json:"stepData"`
+}

--- a/API-tests/workflow_test.go
+++ b/API-tests/workflow_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"log"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func getWorkflowStep(url string) WorkflowStep {
+	res, _ := client.Get(url)
+	b, _ := io.ReadAll(res.Body)
+
+	var m WorkflowStep
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		log.Printf("JSON parsing error, couldn't parse: %v", string(b))
+		log.Printf("JSON parsing error: %v", err.Error())
+	}
+	return m
+}
+
+func setStepCoordinates(stepID string, x string, y string) string {
+	postData := url.Values{}
+	postData.Set("CSRFToken", CsrfToken)
+	postData.Set("stepID", stepID)
+	postData.Set("x", x)
+	postData.Set("y", y)
+
+	res, _ := client.PostForm(RootURL+`api/workflow/1/editorPosition`, postData)
+	bodyBytes, _ := io.ReadAll(res.Body)
+
+	var c string
+	err := json.Unmarshal(bodyBytes, &c)
+	if err != nil {
+		log.Printf("JSON parsing error, couldn't parse: %v", string(bodyBytes))
+	}
+	return c
+}
+
+func TestWorkflow_No_Negative_Step_Coordinates(t *testing.T) {
+	res := setStepCoordinates("1", "-100", "-100")
+
+	got := res
+	want := "1"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Error updating step position = %v, want = %v", got, want)
+	}
+
+	workflowStep := getWorkflowStep(RootURL + "api/workflow/step/1")
+	got = strconv.Itoa(workflowStep.PosX)
+	want = "0"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Saved X position should have min possible value of 0 = %v, want = %v", got, want)
+	}
+	got = strconv.Itoa(workflowStep.PosY)
+	want = "0"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Saved Y position should have min possible value of 0 = %v, want = %v", got, want)
+	}
+}

--- a/API-tests/workflow_test.go
+++ b/API-tests/workflow_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func getWorkflowStep(url string) WorkflowStep {
-	res, _ := client.Get(url)
+func getWorkflowStep(stepID string) WorkflowStep {
+	res, _ := client.Get(RootURL + "api/workflow/step/" + stepID)
 	b, _ := io.ReadAll(res.Body)
 
 	var m WorkflowStep
@@ -24,14 +24,14 @@ func getWorkflowStep(url string) WorkflowStep {
 	return m
 }
 
-func setStepCoordinates(stepID string, x string, y string) string {
+func setStepCoordinates(workflowID string, stepID string, x string, y string) string {
 	postData := url.Values{}
 	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("stepID", stepID)
 	postData.Set("x", x)
 	postData.Set("y", y)
 
-	res, _ := client.PostForm(RootURL+`api/workflow/1/editorPosition`, postData)
+	res, _ := client.PostForm(RootURL + `api/workflow/`+ workflowID + `/editorPosition`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)
 
 	var c string
@@ -42,24 +42,41 @@ func setStepCoordinates(stepID string, x string, y string) string {
 	return c
 }
 
-func TestWorkflow_No_Negative_Step_Coordinates(t *testing.T) {
-	res := setStepCoordinates("1", "-100", "-100")
-
-	got := res
+func TestWorkflow_Set_Step_Coordinates(t *testing.T) {
+	//negative coords use min val of 0
+	got := setStepCoordinates("1", "1", "-100", "-100")
 	want := "1"
 	if !cmp.Equal(got, want) {
-		t.Errorf("Error updating step position = %v, want = %v", got, want)
+		t.Errorf("Error setting step position = %v, want = %v", got, want)
 	}
 
-	workflowStep := getWorkflowStep(RootURL + "api/workflow/step/1")
+	workflowStep := getWorkflowStep("1")
 	got = strconv.Itoa(workflowStep.PosX)
 	want = "0"
 	if !cmp.Equal(got, want) {
 		t.Errorf("Saved X position should have min possible value of 0 = %v, want = %v", got, want)
 	}
 	got = strconv.Itoa(workflowStep.PosY)
-	want = "0"
 	if !cmp.Equal(got, want) {
 		t.Errorf("Saved Y position should have min possible value of 0 = %v, want = %v", got, want)
+	}
+
+	//positive coords should save as given
+	got = setStepCoordinates("1", "1", "200", "500")
+	want = "1"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Error setting step position = %v, want = %v", got, want)
+	}
+
+	workflowStep = getWorkflowStep("1")
+	got = strconv.Itoa(workflowStep.PosX)
+	want = "200"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Saved X position did not match input = %v, want = %v", got, want)
+	}
+	got = strconv.Itoa(workflowStep.PosY)
+	want = "500"
+	if !cmp.Equal(got, want) {
+		t.Errorf("Saved Y position did not match input = %v, want = %v", got, want)
 	}
 }


### PR DESCRIPTION
Go API workflowstep struct and test for setting workflow step position.

Associated with LEAF-4585 to prevent setting of negative workflow step coordinates.
https://github.com/department-of-veterans-affairs/LEAF/pull/2600