### PR TITLE
LEAF TEST 4620 update form test - parentID not required data

### DIFF
--- a/API-tests/formStack_test.go
+++ b/API-tests/formStack_test.go
@@ -25,7 +25,6 @@ func postNewForm() string {
 	postData.Set("CSRFToken", CsrfToken)
 	postData.Set("name", "Test New Form")
 	postData.Set("description", "Test New Form Description")
-	postData.Set("parentID", "")
 
 	res, _ := client.PostForm(RootURL+`api/formEditor/new`, postData)
 	bodyBytes, _ := io.ReadAll(res.Body)


### PR DESCRIPTION
Updates existing new form Go test (formStack_test) to reflect that parentID is not required post data.
This is associated with 4620, which included a bug fix for an issue that was causing new form requests to fail.

