### PR TITLE
LEAF-4636 - username missing in API 

### DIFF
--- a/API-tests/formQuery.go
+++ b/API-tests/formQuery.go
@@ -5,61 +5,62 @@ type FormQueryResponse map[int]FormQueryRecord
 type FormQueryData map[string]any
 
 type FormQuery_Orgchart_Employee struct {
-	FirstName         string  `json:"firstName"`
-	LastName          string  `json:"lastName"`
-	MiddleName        string  `json:"middleName"`
-	Email             string  `json:"email"`
-	UserName          string  `json:"userName"`
+	FirstName  string `json:"firstName"`
+	LastName   string `json:"lastName"`
+	MiddleName string `json:"middleName"`
+	Email      string `json:"email"`
+	UserName   string `json:"userName"`
 }
 
 type FormQueryRecord struct {
-	RecordID                int                          `json:"recordID"`
-	ServiceID               int                          `json:"serviceID"`
-	Date                    int                          `json:"date"`
-	UserID                  string                       `json:"userID"`
-	Title                   string                       `json:"title"`
-	Priority                int                          `json:"priority"`
-	LastStatus              string                       `json:"lastStatus"`
-	Submitted               int                          `json:"submitted"`
-	Deleted                 int                          `json:"deleted"`
-	IsWritableUser          int                          `json:"isWritableUser"`
-	IsWritableGroup         int                          `json:"isWritableGroup"`
-	Service                 string                       `json:"service"`
-	AbbreviatedService      string                       `json:"abbreviatedService"`
-	GroupID                 int                          `json:"groupID"`
-	StepID                  int                          `json:"stepID"`
-	BlockingStepID          int                          `json:"blockingStepID"`
-	LastNotified            string                       `json:"lastNotified"`
-	InitialNotificationSent int                          `json:"initialNotificationSent"`
-	StepTitle               string                       `json:"stepTitle"`
-	CategoryNames           []string                     `json:"categoryNames"`
-	CategoryIDs             []string                     `json:"categoryIDs"`
-	DestructionAge          int                          `json:"destructionAge"`
-	ActionHistory           []FormQueryActionHistory     `json:"action_history"`
-	S1                      FormQueryData                `json:"s1"`
-	UnfilledDependencyData  UnfilledDependencyData       `json:"unfilledDependencyData"`
-	UserMetadata            FormQuery_Orgchart_Employee  `json:"userMetadata"`
-	FirstName               string                       `json:"firstName"`
-	LastName                string                       `json:"lastName"`
+	RecordID                int                         `json:"recordID"`
+	ServiceID               int                         `json:"serviceID"`
+	Date                    int                         `json:"date"`
+	UserID                  string                      `json:"userID"`
+	Title                   string                      `json:"title"`
+	Priority                int                         `json:"priority"`
+	LastStatus              string                      `json:"lastStatus"`
+	Submitted               int                         `json:"submitted"`
+	Deleted                 int                         `json:"deleted"`
+	IsWritableUser          int                         `json:"isWritableUser"`
+	IsWritableGroup         int                         `json:"isWritableGroup"`
+	Service                 string                      `json:"service"`
+	AbbreviatedService      string                      `json:"abbreviatedService"`
+	GroupID                 int                         `json:"groupID"`
+	StepID                  int                         `json:"stepID"`
+	BlockingStepID          int                         `json:"blockingStepID"`
+	LastNotified            string                      `json:"lastNotified"`
+	InitialNotificationSent int                         `json:"initialNotificationSent"`
+	StepTitle               string                      `json:"stepTitle"`
+	CategoryNames           []string                    `json:"categoryNames"`
+	CategoryIDs             []string                    `json:"categoryIDs"`
+	DestructionAge          int                         `json:"destructionAge"`
+	ActionHistory           []FormQueryActionHistory    `json:"action_history"`
+	S1                      FormQueryData               `json:"s1"`
+	UnfilledDependencyData  UnfilledDependencyData      `json:"unfilledDependencyData"`
+	UserMetadata            FormQuery_Orgchart_Employee `json:"userMetadata"`
+	FirstName               string                      `json:"firstName"`
+	LastName                string                      `json:"lastName"`
+	UserName                string                      `json:"userName"`
 }
 
 type FormQueryActionHistory struct {
-	RecordID            int    `json:"recordID"`
-	StepID              int    `json:"stepID"`
-	UserID              string `json:"userID"`
-	Time                int    `json:"time"`
-	Description         string `json:"description"`
-	ActionTextPasttense string `json:"actionTextPasttense"`
-	ActionType          string `json:"actionType"`
-	Comment             string `json:"comment"`
-	ApproverName        string `json:"approverName"`
-	UserMetadata		FormQuery_Orgchart_Employee  `json:"userMetadata"`
+	RecordID            int                         `json:"recordID"`
+	StepID              int                         `json:"stepID"`
+	UserID              string                      `json:"userID"`
+	Time                int                         `json:"time"`
+	Description         string                      `json:"description"`
+	ActionTextPasttense string                      `json:"actionTextPasttense"`
+	ActionType          string                      `json:"actionType"`
+	Comment             string                      `json:"comment"`
+	ApproverName        string                      `json:"approverName"`
+	UserMetadata        FormQuery_Orgchart_Employee `json:"userMetadata"`
 }
 
 type UnfilledDependencyData map[string]UnfilledDependency
 
-type UnfilledDependency struct{
-	Description            string    `json:"description"`
-	ApproverName           string    `json:"approverName"`
-	ApproverUID            string 	 `json:"approverUID"`
+type UnfilledDependency struct {
+	Description  string `json:"description"`
+	ApproverName string `json:"approverName"`
+	ApproverUID  string `json:"approverUID"`
 }

--- a/API-tests/formQuery_test.go
+++ b/API-tests/formQuery_test.go
@@ -244,15 +244,14 @@ func TestFormQuery_FindTwoSteps(t *testing.T) {
 	}
 }
 
-
 /* post a new employee to an orgchart format question and then confirm expected values on orgchart property */
 func TestFormQuery_Employee_Format__Orgchart_Has_Expected_Values(t *testing.T) {
 	mock_orgchart_employee := FormQuery_Orgchart_Employee{
-		FirstName: "Ramon",
-		LastName: "Watsica",
+		FirstName:  "Ramon",
+		LastName:   "Watsica",
 		MiddleName: "Yundt",
-		Email: "Ramon.Watsica@fake-email.com",
-		UserName: "vtrycxbethany",
+		Email:      "Ramon.Watsica@fake-email.com",
+		UserName:   "vtrycxbethany",
 	}
 
 	postData := url.Values{}
@@ -279,7 +278,7 @@ func TestFormQuery_Employee_Format__Orgchart_Has_Expected_Values(t *testing.T) {
 	recData := formRes[11].S1
 
 	dataInterface := recData["id8_orgchart"]
-	orgchart := dataInterface.(map[string]interface {})
+	orgchart := dataInterface.(map[string]interface{})
 	b, _ := json.Marshal(orgchart)
 
 	var org_emp FormQuery_Orgchart_Employee
@@ -336,12 +335,12 @@ func TestFormQuery_Orgchart_Formats__idIndicator_Has_Expected_Values(t *testing.
 	if !cmp.Equal(got, want) {
 		t.Errorf("id49 valid employee, id value got = %v, want = %v", got, want)
 	}
-	got = res[recDataFound].S1[keyGrp]  //Group Title - derived by group lookup of data.data
+	got = res[recDataFound].S1[keyGrp] //Group Title - derived by group lookup of data.data
 	want = "Aluminum Books"
 	if !cmp.Equal(got, want) {
 		t.Errorf("id50 valid group, id value got = %v, want = %v", got, want)
 	}
-	got = res[recDataFound].S1[keyPos]  //Posistion Title (PayPlan-Series-PayGrade) - derived by position lookup of data.data and supsequent orgchart position_data
+	got = res[recDataFound].S1[keyPos] //Posistion Title (PayPlan-Series-PayGrade) - derived by position lookup of data.data and supsequent orgchart position_data
 	want = "Accountability Officer (GS-0343-14)"
 	if !cmp.Equal(got, want) {
 		t.Errorf("id51 valid position, id value got = %v, want = %v", got, want)
@@ -383,26 +382,26 @@ func TestFormQuery_Orgchart_Formats__idIndicator_Has_Expected_Values(t *testing.
 
 	//id values should be null if no data record exists
 	got = res[recNoDataRecord].S1[keyEmp]
-	if(got != nil) {
+	if got != nil {
 		t.Errorf("id49 no employee data (null), id value got = %v", got)
 	}
 	got = res[recNoDataRecord].S1[keyGrp]
-	if(got != nil) {
+	if got != nil {
 		t.Errorf("id50 no group data (null), id value got = %v", got)
 	}
 	got = res[recNoDataRecord].S1[keyPos]
-	if(got != nil) {
+	if got != nil {
 		t.Errorf("id49 no position data (null), id value got = %v", got)
 	}
 }
 
 func TestFormQuery_Records_UserMetadata__Has_Expected_Values(t *testing.T) {
 	mock_orgchart_employee := FormQuery_Orgchart_Employee{
-		FirstName: "Risa",
-		LastName: "Keebler",
+		FirstName:  "Risa",
+		LastName:   "Keebler",
 		MiddleName: "Hyatt",
-		Email: "Risá.Keebler@fake-email.com",
-		UserName: "vtrigzcristal",
+		Email:      "Risá.Keebler@fake-email.com",
+		UserName:   "vtrigzcristal",
 	}
 	//post new request under a username
 	postData := url.Values{}
@@ -491,5 +490,34 @@ func TestFormQuery_Records_UserMetadata__Has_Expected_Values(t *testing.T) {
 	}
 	if !cmp.Equal(gotLastName, wantLast) {
 		t.Errorf("Record last name got = %v, want = %v", gotLastName, wantLast)
+	}
+}
+
+func TestForm_VerifyInitiator(t *testing.T) {
+
+	url := RootURL + `api/form/query/?q={"terms":[{"id":"recordID","operator":"=","match":"5","gate":"AND"},{"id":"deleted","operator":"=","match":0,"gate":"AND"}],"joins":["initiatorName"],"sort":{}}&x-filterData=recordID,lastName,firstName,userName`
+	res, _ := client.Get(url)
+	b, _ := io.ReadAll(res.Body)
+
+	var formQueryResponse FormQueryResponse
+	err := json.Unmarshal(b, &formQueryResponse)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if formQueryResponse[5].RecordID == 0 {
+		t.Error("RecordID not set")
+	}
+
+	if formQueryResponse[5].FirstName == "" {
+		t.Error("FirstName not set")
+	}
+
+	if formQueryResponse[5].LastName == "" {
+		t.Error("LastName not set")
+	}
+
+	if formQueryResponse[5].UserName == "" {
+		t.Error("UserName not set")
 	}
 }

--- a/API-tests/formQuery_test.go
+++ b/API-tests/formQuery_test.go
@@ -505,10 +505,6 @@ func TestForm_VerifyInitiator(t *testing.T) {
 		t.Error(err)
 	}
 
-	if formQueryResponse[5].RecordID == 0 {
-		t.Error("RecordID not set")
-	}
-
 	if formQueryResponse[5].FirstName == "" {
 		t.Error("FirstName not set")
 	}


### PR DESCRIPTION
This is the test to go along with https://github.com/department-of-veterans-affairs/LEAF/pull/2650

I have this setup to test only for the presence of the initiators first, last and user names. 

Also for this pr I had opened up the formQuery.go and the plugin I use with go auto formatted this file as you can see, I do not want to fight the plugins best wishes since this does bring in imports and fixes formatting to be consistent with the go coding standard.  
https://marketplace.visualstudio.com/items?itemName=golang.go
