### PR TITLE
test LEAF 4639 update emp orgchart struct and associated test

### DIFF
--- a/API-tests/formQuery.go
+++ b/API-tests/formQuery.go
@@ -10,6 +10,7 @@ type FormQuery_Orgchart_Employee struct {
 	MiddleName        string  `json:"middleName"`
 	Email             string  `json:"email"`
 	UserName          string  `json:"userName"`
+	EmpUID            int     `json:"empUID"`
 }
 
 type FormQueryRecord struct {

--- a/API-tests/formQuery_test.go
+++ b/API-tests/formQuery_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -248,6 +249,7 @@ func TestFormQuery_FindTwoSteps(t *testing.T) {
 /* post a new employee to an orgchart format question and then confirm expected values on orgchart property */
 func TestFormQuery_Employee_Format__Orgchart_Has_Expected_Values(t *testing.T) {
 	mock_orgchart_employee := FormQuery_Orgchart_Employee{
+		EmpUID: 201,
 		FirstName: "Ramon",
 		LastName: "Watsica",
 		MiddleName: "Yundt",
@@ -312,6 +314,11 @@ func TestFormQuery_Employee_Format__Orgchart_Has_Expected_Values(t *testing.T) {
 	want = mock_orgchart_employee.UserName
 	if !cmp.Equal(got, want) {
 		t.Errorf("userName got = %v, want = %v", got, want)
+	}
+	got = strconv.Itoa(org_emp.EmpUID)
+	want = strconv.Itoa(mock_orgchart_employee.EmpUID)
+	if !cmp.Equal(got, want) {
+		t.Errorf("empUID got = %v, want = %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Re-add EmpUID to orgchart employee struct and test case.

Associated fix branch
https://github.com/department-of-veterans-affairs/LEAF/pull/2653

