### PR TITLE
Test for subsequent JS getWorkflow() calls

### DIFF
--- a/API-tests/database/portal_test_db.sql
+++ b/API-tests/database/portal_test_db.sql
@@ -6343,7 +6343,7 @@ INSERT INTO `records` (`recordID`, `date`, `serviceID`, `userID`, `title`, `prio
 (11,	1694021465,	0,	'tester',	'TestFormQuery_Employee_Format__Orgchart_Has_Expected_Values',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
 (12,	1694021465,	0,	'tester',	'TestFormQuery_InitiatorName',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
 (13,	1694021465,	0,	'tester_disabled',	'TestFormQuery_Initiator_Disabled__Empty_Metadata',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"\", \"lastName\": \"\", \"userName\": \"\", \"firstName\": \"\", \"middleName\": \"\"}'),
-(14,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
+(14,	1694021465,	0,	'tester',	'Workflow Form Fields',	0,	'Approved',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
 (15,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
 (16,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
 (17,	1694021465,	0,	'tester',	'Available for test case',	0,	'Submitted',	1694021485,	0,	0,	1,	'{\"email\": \"tester.tester@fake-email.com\", \"lastName\": \"Tester\", \"userName\": \"tester\", \"firstName\": \"Tester\", \"middleName\": \"\"}'),
@@ -12117,7 +12117,7 @@ INSERT INTO `records_workflow_state` (`recordID`, `stepID`, `blockingStepID`, `l
 (11,	1,	0,	'2023-09-06 17:31:25',	0),
 (12,	1,	0,	'2023-09-06 17:31:25',	0),
 (13,	1,	0,	'2023-09-06 17:31:25',	0),
-(14,	1,	0,	'2023-09-06 17:31:25',	0),
+(14,	2,	0,	'2023-09-06 17:31:25',	0),
 (15,	1,	0,	'2023-09-06 17:31:25',	0),
 (16,	1,	0,	'2023-09-06 17:31:25',	0),
 (17,	1,	0,	'2023-09-06 17:31:25',	0),
@@ -13303,6 +13303,8 @@ CREATE TABLE `step_modules` (
   UNIQUE KEY `stepID_moduleName` (`stepID`,`moduleName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
+INSERT INTO `step_modules` (`stepID`, `moduleName`, `moduleConfig`) VALUES
+(2,	'LEAF_workflow_indicator',	'{\"indicatorID\":3}');
 
 DROP TABLE IF EXISTS `tags`;
 CREATE TABLE `tags` (

--- a/end2end/tests/printview.spec.ts
+++ b/end2end/tests/printview.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('workflow form fields load after subsequent getWorkflow() executions', async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/index.php?a=printview&recordID=14');
+
+  // Wait for relevant section to fully load
+  await expect(page.locator('div[id^="workflowStepModule"][id$="_container"]')).toContainText('Single line text');
+
+  // Simulate getWorkflow() invocation from a custom script
+  await page.evaluate(() => workflow.getWorkflow(14));
+
+  // The workflow form fields should still be visible
+  await expect(page.locator('div[id^="workflowStepModule"][id$="_container"]')).toContainText('Single line text');
+
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+});


### PR DESCRIPTION
**Merging this PR Requires https://github.com/department-of-veterans-affairs/LEAF/pull/2661 to be merged first**

This helps prevent future issues related to https://github.com/department-of-veterans-affairs/LEAF/pull/2661

## Testing
1. From the main repo: `git checkout master`
2. Run this test, we should expect it to fail
3. From the main repo: `git checkout fix_subsequent_workflow_loads`
4. Run this test, we should expect it to pass