### PR TITLE
LEAF-4614 - Test for double slash redirect

### DIFF
--- a/API-tests/redirect_test.go
+++ b/API-tests/redirect_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestRedirection(t *testing.T) {
+	redirectURL := RootURL + "/admin//?a=mod_templates&file=view_homepage.tpl"
+
+	resp, err := client.Get(redirectURL)
+	if err != nil {
+		t.Errorf("Error loading page " + err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	if redirectURL == resp.Request.URL.String() {
+		t.Errorf("Url did not redirect want:" + redirectURL + " got:" + resp.Request.URL.String())
+	}
+
+}


### PR DESCRIPTION
This is the test for : https://github.com/department-of-veterans-affairs/LEAF/pull/2658

I did not see a good place for this test to fit in. I created a new file specifically for redirects. I am thinking this file could change to something to verify presence of pages/images and verify redirects work. I could see this coming in handy for verify things like images moves or replacements.

NOTE: This does require your container to be rebuilt using the updated nginx configuration.