### PR TITLE
Test DB: add workflow field to a multi-requirement step

### DIFF
--- a/API-tests/database/portal_test_db.sql
+++ b/API-tests/database/portal_test_db.sql
@@ -13304,6 +13304,7 @@ CREATE TABLE `step_modules` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 INSERT INTO `step_modules` (`stepID`, `moduleName`, `moduleConfig`) VALUES
+(1,	'LEAF_workflow_indicator',	'{\"indicatorID\":3}'),
 (2,	'LEAF_workflow_indicator',	'{\"indicatorID\":3}');
 
 DROP TABLE IF EXISTS `tags`;


### PR DESCRIPTION
This helps test https://github.com/department-of-veterans-affairs/LEAF/pull/2672 , and requires it to be merged for tests to pass.

In [LEAF PR#2661](https://github.com/department-of-veterans-affairs/LEAF/pull/2661), it was discovered that the following conditions prevented workflows from loading correctly when reviewing a record:

1. The record is on a step with multiple requirements
2. AND the step has a workflow field configured
3. AND the current user has access to more than one of the requirements (such as an admin)