### PR TITLE
Leaf 4682 - platform portal api test

### DIFF
--- a/API-tests/group_test.go
+++ b/API-tests/group_test.go
@@ -70,8 +70,11 @@ func postNewGroup() string {
 	return c
 }
 
-func postNewTag(groupID string) string {
+func postNewTag(groupID string, tag string) string {
 	postData := url.Values{}
+	if tag != "" {
+		postData.Set("tag", tag)
+	}
 	postData.Set("CSRFToken", CsrfToken)
 
 	res, _ := client.PostForm(RootOrgchartURL+`api/group/`+groupID+`/tag`, postData)
@@ -97,9 +100,12 @@ func importGroup(groupID string) string {
 	return c
 }
 
-func removeNexusGroup(postUrl string) error {
+func removeFromNexus(postUrl string, tag string) error {
 
 	data := url.Values{}
+	if tag != "" {
+		data.Set("tag", tag)
+	}
 	data.Set("CSRFToken", CsrfToken)
 
 	req, err := http.NewRequest("DELETE", postUrl, strings.NewReader(data.Encode()))
@@ -144,7 +150,7 @@ func TestGroup_syncServices(t *testing.T) {
 	groupID := postNewGroup()
 	id, _ := strconv.Atoi(groupID)
 	var passed = false
-	postNewTag(groupID)
+	postNewTag(groupID, "")
 	importGroup(groupID)
 
 	// check that the group exists in both nexus and portal
@@ -176,7 +182,7 @@ func TestGroup_syncServices(t *testing.T) {
 	}
 
 	// remove this group from the nexus
-	err := removeNexusGroup(fmt.Sprintf("%sapi/group/%s", RootOrgchartURL, groupID))
+	err := removeFromNexus(fmt.Sprintf("%sapi/group/%s", RootOrgchartURL, groupID), "")
 
 	if err != nil {
 		t.Error(err)
@@ -217,5 +223,50 @@ func TestGroup_syncServices(t *testing.T) {
 
 	if passed == true {
 		t.Errorf("Portal group was not removed and should have been")
+	}
+}
+
+func TestGroup_removeTag(t *testing.T) {
+	// add a tag to a group
+	id := "34"
+	id_int, _ := strconv.Atoi(id)
+	passed := false
+	tag_name := "Academy_Demo1"
+	postNewTag(id, tag_name)
+
+	// check to make sure tag was added
+	o_groups := getNexusGroup(RootOrgchartURL + `api/group/list`)
+
+	for _, o_group := range o_groups {
+		if id_int == o_group.GroupID {
+			passed = true
+			break
+		}
+	}
+
+	if passed == false {
+		t.Errorf("The tag was not found in this group")
+	}
+
+	// remove the tag
+	err := removeFromNexus(fmt.Sprintf("%sapi/group/%s/tag?", RootOrgchartURL, id), tag_name)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check to make sure tag was removed
+	passed = false
+	o_groups = getNexusGroup(RootOrgchartURL + `api/group/list`)
+
+	for _, o_group := range o_groups {
+		if (id_int == o_group.GroupID) && (tag_name == o_group.GroupTitle) {
+			passed = true
+			break
+		}
+	}
+
+	if passed == true {
+		t.Errorf("The tag was not removed from this group")
 	}
 }

--- a/API-tests/group_test.go
+++ b/API-tests/group_test.go
@@ -70,6 +70,7 @@ func postNewGroup() string {
 	return c
 }
 
+// postNewTag creates a new tag for the given groupID
 func postNewTag(groupID string, tag string) string {
 	postData := url.Values{}
 	if tag != "" {
@@ -100,6 +101,8 @@ func importGroup(groupID string) string {
 	return c
 }
 
+// changed this method so that it could be used more universally, with the url being passed in
+// more variables could be needed to go with the url
 func removeFromNexus(postUrl string, tag string) error {
 
 	data := url.Values{}
@@ -226,6 +229,7 @@ func TestGroup_syncServices(t *testing.T) {
 	}
 }
 
+// A test to remove a tag from the nexus group
 func TestGroup_removeTag(t *testing.T) {
 	// add a tag to a group
 	id := "34"

--- a/API-tests/platform.go
+++ b/API-tests/platform.go
@@ -1,0 +1,9 @@
+package main
+
+type PlatformResponse []Platform
+
+type Platform struct {
+	LaunchpadID          int        `json:"launchpadID"`
+	Site_path            string     `json:"site_path"`
+	OrgchartImportTags   []string   `json:"tags"`
+}

--- a/API-tests/platform_test.go
+++ b/API-tests/platform_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// get all the portal import tags for the given orgchart
 func getOrgchartImportTags(url string) PlatformResponse {
 	res, _ := client.Get(url)
 	b, _ := io.ReadAll(res.Body)
@@ -23,6 +24,9 @@ func getOrgchartImportTags(url string) PlatformResponse {
 	return m
 }
 
+// this test gets all the portals for the given orgchart and makes sure that
+// the correct correct number of portals are returned, and that the correct
+// tag is returned for the first portal
 func TestPlatform_getOrgchartTags(t *testing.T) {
 	portals := getOrgchartImportTags(RootOrgchartURL + `api/platform/portal/_LEAF_Nexus`)
 

--- a/API-tests/platform_test.go
+++ b/API-tests/platform_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func getOrgchartImportTags(url string) PlatformResponse {
+	res, _ := client.Get(url)
+	b, _ := io.ReadAll(res.Body)
+
+	var m PlatformResponse
+	err := json.Unmarshal(b, &m)
+
+	if err != nil {
+		log.Printf("JSON parsing error, couldn't parse: %v", string(b))
+		log.Printf("JSON parsing error: %v", err.Error())
+	}
+	return m
+}
+
+func TestPlatform_getOrgchartTags(t *testing.T) {
+	portals := getOrgchartImportTags(RootOrgchartURL + `api/platform/portal/_LEAF_Nexus`)
+
+	count := len(portals)
+	retrieved := 1
+
+	if !cmp.Equal(count, retrieved) {
+		t.Errorf("Array size = %v, wanted = %v", count, retrieved)
+	}
+
+	got := portals[0].LaunchpadID
+	want := 0
+	if !cmp.Equal(got, want) {
+		t.Errorf("LaunchpadId = %v, want = %v", got, want)
+	}
+
+	received := portals[0].Site_path
+	wanted := "/LEAF_Request_Portal"
+	if !cmp.Equal(received, wanted) {
+		t.Errorf("Site Path = %v, want = %v", received, wanted)
+	}
+
+	received = portals[0].OrgchartImportTags[0]
+	wanted = "Academy_Demo1"
+	if !cmp.Equal(received, wanted) {
+		t.Errorf("Tag = %v, want = %v", received, wanted)
+	}
+}


### PR DESCRIPTION
This API test covers the new platform/portal end point as well as the delete tag both on the nexus side. This test goes with Leaf 4571 on the Leaf repo.