### PR TITLE
Cleanup git status

### DIFF
--- a/end2end/.gitignore
+++ b/end2end/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/forms/


### PR DESCRIPTION
This cleans up `git status`, as end2end tests create temporary files in `./end2end/forms/`.