### PR TITLE
Add test for newly created yellow-highlighted untitled row

### DIFF
--- a/end2end/tests/lifecycleReportBuilder.spec.ts
+++ b/end2end/tests/lifecycleReportBuilder.spec.ts
@@ -359,3 +359,33 @@ test('Go to UID Link', async ({ page }) => {
   // contains 'This is an otter'
   await expect(page.locator('#data_3_1')).toContainText('This is an otter');
 });
+
+test('verify the newly created row is highlighted and contains "untitled"', async ({ page }) => {
+  // 1) Navigate & build the report…
+  await page.goto('https://host.docker.internal/Test_Request_Portal/?a=reports&v=3');
+  await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
+  await page.getByRole('option', { name: 'Type' }).click();
+  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('option', { name: 'Input Formats' }).click();
+  await page.getByRole('button', { name: 'Next Step' }).click();
+  await page.locator('#indicatorList').getByText('Input Formats').click();
+  await page.getByTitle('indicatorID: 45\ncheckboxes (LEAF-check)').locator('span').click();
+  await page.getByRole('button', { name: 'Generate Report' }).click();
+  await expect(page.locator('#reportStats')).toContainText('records');
+  await page.waitForSelector('table tbody tr');
+
+  // 2) Create the new row
+  await page.getByRole('button', { name: /Create Row/i }).click();
+
+  // 3) Target the yellow-highlighted "untitled" row
+  const highlightedRow = page.locator(
+    'table tbody tr[style*="background-color"]',
+    { hasText: 'untitled' }
+  );
+
+  // 4) Wait for it and assert
+  await expect(highlightedRow).toBeVisible();
+  await expect(highlightedRow).toContainText('untitled');
+});
+
+


### PR DESCRIPTION
This test verifies the “Create Row” feature in Report Builder actually produces a new row with the `untitled` title and the yellow highlight. 
![image](https://github.com/user-attachments/assets/de3e70e8-a7bd-4f68-b263-984b172470ea)
![image](https://github.com/user-attachments/assets/34d6a0d0-4e6d-45e9-8a8c-45aacf328e57)
