### PR TITLE
Strengthen lifecycleSimpleTravel.spec.ts and remove interfering tests

### DIFF
--- a/end2end/tests/adminPanelLinks.spec.ts
+++ b/end2end/tests/adminPanelLinks.spec.ts
@@ -84,16 +84,6 @@ test('Go to Search Database', async ({ page }) => {
   await expect(page.locator('#headerTab')).toContainText('Search Database');
 });
 
-test('Go to Sync Services', async ({ page }) => {
-  await page.getByRole('button', { name: 'Sync Services Update' }).click();
-  await expect(page.getByRole('heading')).toContainText('Sync Services');
-});
-
-test('Go to Update Database', async ({ page }) => {
-  await page.getByRole('button', { name: 'Update Database Updates the' }).click();
-  await expect(page.getByRole('heading')).toContainText('Update Database');
-});
-
 test('Go to Import Spreadsheet', async ({ page }) => {
   await page.getByRole('button', { name: 'Import Spreadsheet Rows to' }).click();
   await expect(page.locator('#uploadBox')).toContainText('Choose a Spreadsheet');

--- a/end2end/tests/homepage.spec.ts
+++ b/end2end/tests/homepage.spec.ts
@@ -7,7 +7,7 @@ test('search record ID using quick search', async ({ page }, testInfo) => {
 
   // Use .pressSequentially since the UX does search-as-you-type
   await page.getByLabel('Enter your search text').pressSequentially('500');
-  await expect(page.getByRole('link', { name: '500' })).toBeInViewport();
+  await expect(page.getByRole('link', { name: '500', exact: true })).toBeInViewport();
 
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
@@ -24,7 +24,7 @@ test('search record ID using advanced options', async ({ page }, testInfo) => {
   await page.getByLabel('text', { exact: true }).click();
   await page.getByLabel('text', { exact: true }).fill('500');
   await page.getByRole('button', { name: 'Apply Filters' }).click();
-  await expect(page.getByRole('link', { name: '500' })).toBeInViewport();
+  await expect(page.getByRole('link', { name: '500', exact: true })).toBeInViewport();
 
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });

--- a/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -264,18 +264,15 @@ test('navigate to the Report Builder, find the travel request, and check status'
   await page.getByText('Report Builder').click();
 
   // Click on the "Current Status" link
-  await expect(page.getByRole('cell', { name: 'Current Status' }).locator('a')).toBeVisible();
   await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
 
   // Select the "Type" option
-  await expect(page.getByRole('option', { name: 'Type' })).toBeVisible();
   await page.getByRole('option', { name: 'Type' }).click();
 
   // After clicking Type, we should expect the dropdown containing "Resolved" to be replaced
   await expect(page.getByRole('cell', { name: 'Resolved' }).locator('a')).not.toBeVisible();
 
   // Select "Complex Form" from the list
-  await expect(page.locator('td').nth(4)).toBeVisible();
   await page.locator('td').nth(4).click();
 
   // The list might be very long, so search for it
@@ -284,11 +281,9 @@ test('navigate to the Report Builder, find the travel request, and check status'
   await page.getByRole('option', { name: uniqueText }).click();
 
   // Proceed to the next step
-  await expect(page.getByRole('button', { name: 'Next Step' })).toBeVisible();
   await page.getByRole('button', { name: 'Next Step' }).click();
 
   // Open the status indicator list
-  await expect(page.locator('#indicatorList').getByText('Current Status')).toBeVisible();
   await page.locator('#indicatorList').getByText('Current Status').click();
   await page.locator('#indicatorList').getByText(uniqueText, { exact: true }).click();
 
@@ -301,7 +296,6 @@ test('navigate to the Report Builder, find the travel request, and check status'
   */
 
   // Generate the report
-  await expect(page.getByRole('button', { name: 'Generate Report' })).toBeVisible();
   await page.getByRole('button', { name: 'Generate Report' }).click();
 
   // Confirm the approval status is visible

--- a/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -271,10 +271,15 @@ test('navigate to the Report Builder, find the travel request, and check status'
   await expect(page.getByRole('option', { name: 'Type' })).toBeVisible();
   await page.getByRole('option', { name: 'Type' }).click();
 
-  // Select "Complex Form" from the list
-  await expect(page.getByRole('cell', { name: 'Complex Form' }).locator('a')).toBeVisible();
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  // After clicking Type, we should expect the dropdown containing "Resolved" to be replaced
+  await expect(page.getByRole('cell', { name: 'Resolved' }).locator('a')).not.toBeVisible();
 
+  // Select "Complex Form" from the list
+  await expect(page.locator('td').nth(4)).toBeVisible();
+  await page.locator('td').nth(4).click();
+
+  // The list might be very long, so search for it
+  await page.keyboard.type(uniqueText);
   // Choose the specific travel request
   await page.getByRole('option', { name: uniqueText }).click();
 


### PR DESCRIPTION
This resolves flakiness and improves compatibility with other tests.

- It's not possible to rely on a specific form type to appear first in the dropdown, because other tests might add new forms. Instead of relying on the form type, this test now relies on the absence of the default `Resolved` option in a dropdown.
- Dropdown lists can potentially be very long, which places expected values out of the viewport. This test will now search for the specific value before attempting to click it.
- Remove miscellaneous redundant operations
- Remove tests that interfere with the database: https://github.com/department-of-veterans-affairs/LEAF-Automated-Tests/pull/98/commits/81697f4f74c4d5ba681ce23e796834e6be7ed832 These will need to be organized a different way.
- Require exact matches on the homepage to avoid collisions