### PR TITLE
Update Report Builder category dropdown specificity 

### DIFF
--- a/end2end/tests/lifecycleReportBuilder.spec.ts
+++ b/end2end/tests/lifecycleReportBuilder.spec.ts
@@ -28,7 +28,7 @@ test('Correct Data Columns Available to Select', async ({ page}) => {
   // Filter by Type IS General Form
   await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
   await page.getByRole('option', { name: 'Type' }).click();
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'General Form' }).click();
   await page.getByRole('button', { name: 'Next Step' }).click();
 
@@ -49,7 +49,7 @@ test('Correct Columns Displayed', async ({ page }) => {
   // Filter by Type IS General Form
   await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
   await page.getByRole('option', { name: 'Type' }).click();
-  await page.getByRole('cell', { name: 'Complex Form' }).click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'General Form' }).click();
   await page.getByRole('button', { name: 'Next Step' }).click();
 
@@ -183,7 +183,7 @@ test('Add a New Row and Populate', async ({ page }) => {
   // Set filter to Type IS Input Formats
   await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
   await page.getByRole('option', { name: 'Type' }).click();
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'Input Formats' }).click();
   await page.getByRole('button', { name: 'Next Step' }).click();
 
@@ -277,7 +277,7 @@ test('Report Allows Negative Currency', async ({ page}) => {
   await page.getByRole('option', { name: 'Type' }).click();
 
   // Choose reports which use the Input Formats form
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'Input Formats' }).click();
   await page.getByRole('button', { name: 'Next Step' }).click();
   await page.locator('#indicatorList').getByText('Input Formats').click();
@@ -314,7 +314,7 @@ test('Go to UID Link', async ({ page }) => {
   // Change search filter to Type IS General Form
   await page.getByRole('cell', { name: 'Current Status' }).locator('a').click();
   await page.getByRole('option', { name: 'Type' }).click();
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'General Form' }).click();
 
   // Add 'AND'to the search filter

--- a/end2end/tests/lifecycleSimpleTravel.spec.ts
+++ b/end2end/tests/lifecycleSimpleTravel.spec.ts
@@ -272,8 +272,8 @@ test('navigate to the Report Builder, find the travel request, and check status'
   await page.getByRole('option', { name: 'Type' }).click();
 
   // Select "Complex Form" from the list
-  await expect(page.getByRole('cell', { name: 'Complex Form' }).locator('a')).toBeVisible();
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await expect(page.getByRole('cell').locator('select[aria-label="categories"] + div a')).toBeVisible();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
 
   // Choose the specific travel request
   await page.getByRole('option', { name: uniqueText }).click();

--- a/end2end/tests/reportBuilder.spec.ts
+++ b/end2end/tests/reportBuilder.spec.ts
@@ -296,7 +296,7 @@ test('Report builder workflow and create row button functionality', async ({ pag
   await expect(typeOption).toBeVisible();
   await typeOption.click();
 
-  const complexFormLink = page.getByRole('cell', { name: 'Complex Form' }).locator('a');
+  const complexFormLink = page.getByRole('cell').locator('select[aria-label="categories"] + div a');
   await expect(complexFormLink).toBeVisible();
   await complexFormLink.click();
 
@@ -357,7 +357,7 @@ test('Report Allows Negative Currency', async ({ page}) => {
   await page.getByRole('option', { name: 'Type' }).click();
 
   // Choose reports which use the Input Formats form
-  await page.getByRole('cell', { name: 'Complex Form' }).locator('a').click();
+  await page.getByRole('cell').locator('select[aria-label="categories"] + div a').click();
   await page.getByRole('option', { name: 'Input Formats' }).click();
   await page.getByRole('button', { name: 'Next Step' }).click();
   await page.locator('#indicatorList').getByText('Input Formats').click();


### PR DESCRIPTION
## Summary
A number of E2E tests were using name 'Complex Form' as part of the locator for the category dropdown.  This name is not consistent but is dependent on available forms.  Updated so that it is associated with the categories dropdown.


## Testing
Report Builder E2E tests with recent issues should now pass