### PR TITLE
End 2 End Testing for Leaf 4823 inbox column inconsistencies

### DIFF
--- a/end2end/tests/AdjustedReportBuilder.spec.ts
+++ b/end2end/tests/AdjustedReportBuilder.spec.ts
@@ -158,7 +158,7 @@ test('Redirect to search filter and Generate Report with Approval History column
   await dataFieldLink.click();
 
   // Select the role option
-  const roleOption = page.getByRole('option', { name: 'LEAF Developer Console: Supervisor' });
+  const roleOption = page.locator('ul.chosen-results li.active-result:nth-child(1)').first();
   await expect(roleOption).toBeVisible();
   await roleOption.click();
 

--- a/end2end/tests/AdjustedReportBuilder.spec.ts
+++ b/end2end/tests/AdjustedReportBuilder.spec.ts
@@ -213,17 +213,6 @@ test('Update and revert report title from pop-up window', async ({ page }) => {
   await expect(initialReportTitle).toHaveText('Available for test case');
 });
 
-// test('Navigation to record page on UID link click', async ({ page }) => {
-//   await page.goto("https://host.docker.internal/Test_Request_Portal/?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJHSAHASQBEQAaEAez2gEMwKpsBCAXjJBjoGMALbKCHAoAbAG4Qs5AOZ0I2AIIA5EgF9S6LIhAYIwiJEmVqUOg2xtynMLyQAGabIXKQKgLrkAVhTQA7BChwwOgBXBHJfNDA0UyhFGhg5dxwGMCRgNRBhNBhIpABGW0LyLJywAHkAMwq4fTsVIA%3D%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAi2QoAri2a0G%2BMMzboOeHn0iwEKDDgXRiEHeln1Gi6stU8AukA");
-
-//   // UID Link
-//   const UID = page.getByRole('link', { name: '956' });
-//   await UID.waitFor();
-//   await UID.click();
-
-//   // Validate the record page opens with the correct UID
-//   await expect(page.locator('#headerTab')).toContainText('Request #956');
-// });
 
 test('Navigation to record page on UID link click', async ({ page }) => {
   await page.goto("https://host.docker.internal/Test_Request_Portal/?a=reports&v=3&query=N4IgLgpgTgtgziAXAbVASwCZJHSAHASQBEQAaEAez2gEMwKpsBCAXjJBjoGMALbKCHAoAbAG4Qs5AOZ0I2AIIA5EgF9S6LIhAYIwiJEmVqUOg2xtynMLyQAGabIXKQKgLrkAVhTQA7BChwwOgBXBHJfNDA0UyhFGhg5dxwGMCRgNRBhNBhIpABGW0LyLJywAHkAMwq4fTsVIA%3D%3D%3D&indicators=NobwRAlgdgJhDGBDALgewE4EkAiYBcYyEyANgKZgA0YUiAthQVWAM4bL4AMAvpeNHCRosuAi2QoAri2a0G%2BMMzboOeHn0iwEKDDgXRiEHeln1Gi6stU8AukA");

--- a/end2end/tests/AdjustedReportBuilder.spec.ts
+++ b/end2end/tests/AdjustedReportBuilder.spec.ts
@@ -156,6 +156,12 @@ test('Redirect to search filter and Generate Report with Approval History column
   const dataFieldLink = page.locator('a span', { hasText: 'Any standard data field' });
   await expect(dataFieldLink).toBeVisible();
   await dataFieldLink.click();
+
+  // Select the role option
+  const roleOption = page.getByRole('option', { name: 'LEAF Developer Console: Supervisor' });
+  await expect(roleOption).toBeVisible();
+  await roleOption.click();
+
   // Proceed to the next step
   const nextStepButton = page.getByRole('button', { name: 'Next Step' });
   await expect(nextStepButton).toBeVisible();

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -4,24 +4,31 @@ import { test, expect } from '@playwright/test';
 test.describe.configure({ mode: 'serial' });
 
 //Global Variables
-let siteMapname = 'LEAF 4832 - Customization';
+let randNum = Math.random();
+let siteMapname = `LEAF 4832 - Customization`;
 let siteMapDesc = 'Testing for LEAF 4823 Customization';
+let leafSiteCard = 'LEAF 4832 - CustomizationTesting for LEAF 4823 Customization';
 let siteMapURL = 'https://host.docker.internal/Test_Request_Portal/';
 let siteMapColor = '#5d1adb';
 let siteMapFontColor = '#e2db08';
 let serviceRequest ='LEAF 4832 - Request';
 let stapledRequest = 'LEAF 4832 - Stapled Request';
 let stapleName = 'Test IFTHEN staple | Multiple person designated';
+let requestId;
+let stapledRequestId;
 
 
 
 //Create Sitemap Card
 test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
   await page.getByRole('link', { name: 'Admin Panel' }).click();
   await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
 
   await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+
+  //Style the Sitemap
   await page.getByRole('button', { name: '+ Add Site' }).click();
   await page.locator('#button-title').click();
   await page.locator('#button-title').fill(siteMapname);
@@ -39,7 +46,7 @@ test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Save Change' }).click();
 
   //Verify the customized card is present
-  await expect(page.getByText('LEAF 4832 - CustomizationTesting for LEAF 4823 Customization')).toBeVisible();
+  await expect(page.getByText(leafSiteCard)).toBeVisible();
  
   //Screenshot
   const screenshot = await page.screenshot();
@@ -57,8 +64,8 @@ test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
   await page.getByText('Inbox Review and apply').click();
 
   //Verify the customization is present 
-  await expect(page.locator('#inbox').getByText('LEAF 4832 - Customization')).toBeVisible();
-  await expect(page.locator('#indexSites')).toContainText('LEAF 4832 - Customization');
+  await expect(page.locator('#inbox').getByText(siteMapname)).toBeVisible();
+  await expect(page.locator('#indexSites')).toContainText(siteMapname);
 
 
   //Verify display based on View
@@ -85,11 +92,15 @@ test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
    //Role View
    await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
-  await page.getByRole('button', { name: 'Toggle sections' }).click();
-    const uidColrole = page.locator('text=UID').nth(0);
+
+  const dynTxt = 'Tester Tester View';
+  const dynRegex = new RegExp(`^${dynTxt}.*`);
+  await page.getByRole('button', { name: dynRegex}).click();
+
+  const uidColrole = page.locator('text=UID').nth(0);
   expect(await uidColrole.isVisible()).toBeTruthy();
 
-  const serviceColrole = page.locator('text=Service').nth(1);
+  const serviceColrole = page.locator('text=Service').nth(2);
   expect(await serviceColrole.isVisible).toBeTruthy();
 
   const titleColrole = page.locator('text=Title').nth(0);
@@ -110,7 +121,7 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   await page.getByRole('link', { name: 'Admin Panel' }).click();
   await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
   await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
-  await expect(page.getByText('LEAF 4832 - Customization', { exact: true })).toBeVisible();
+  await expect(page.getByText(siteMapname, { exact: true })).toBeVisible();
 
  //Add Customization
   await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('p');
@@ -125,14 +136,15 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
 
-  await expect(page.getByRole('button', { name: 'Toggle sections' })).toBeVisible();
-  await page.getByRole('button', { name: 'Toggle sections' }).click();
+  const dynTxt = 'Tester Tester View';
+  const dynRegex = new RegExp(`^${dynTxt}.*`);
+  await page.getByRole('button', { name: dynRegex}).click();
 
   //Verify Role Customization
   const uidColrole = page.locator('text=UID').nth(0);
   expect(await uidColrole.isVisible()).toBeTruthy();
 
-  const serviceColrole = page.locator('text=Service').nth(1);
+  const serviceColrole = page.locator('text=Service').nth(2);
   expect(await serviceColrole.isVisible).toBeTruthy();
 
   const titleColrole = page.locator('text=Title').nth(0);
@@ -153,7 +165,10 @@ test('Customized Column Display', async ({ page }, testInfo) => {
 
  //Form View
   await page.getByRole('button', { name: 'Organize by Forms' }).click();
-  await page.getByRole('button', { name: 'Toggle sections' }).click();
+ 
+  const dynTxt2 = 'Complex Form';
+  const dynRegex2 = new RegExp(`^${dynTxt2}.*`);
+  await page.getByRole('button', { name: dynRegex2}).click();
   
   //Complex Form View
   const uidCol = page.locator('text=UID').nth(0);
@@ -242,11 +257,22 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   //Enter the Reviewer Information
   await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
 
+  //Get UID
+  requestId = await page.textContent('#headerTab');
+  console.log('Text inside span:', requestId);
+  let str: string = requestId;
+  let parts = str.split("#", 2);
+  let firstPart = parts[0];
+  let secondPart = parts[1];
+  console.log(firstPart, secondPart);
+  requestId =secondPart;
+  
+
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
 
-    await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
 
@@ -272,24 +298,32 @@ test('View Request in Inbox', async ({ page }, testInfo) => {
 
   await page.getByText('Review and apply actions to').click();
 
-  await expect(page.locator('#inbox').getByText('LEAF 4832 - Customization')).toBeVisible();
+  await expect(page.locator('#inbox').getByText(siteMapname)).toBeVisible();
   await expect(page.getByRole('button', { name: 'View as Admin' })).toBeVisible();
   
 
  // await page.getByRole('button', {name:'Multiple person designated'}).click();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
   await page.getByRole('button', { name: 'View as Admin' }).click();
-  await page.getByRole('button', { name: 'Adan Wolf View 1 requests' }).click();
+
+  const dynTxt = 'Adan Wolf View ';
+  const dynRegex = new RegExp(`^${dynTxt}.*`);
+  await page.getByRole('button', { name: dynRegex}).click();
+ 
 
  //Verify Text
  
-  await expect(page.getByRole('cell', { name: 'Multiple person designated' })).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'LEAF 4832 - Request' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: requestId })).toBeVisible();
   await expect(page.getByRole('cell', { name: 'Adan Wolf' })).toBeVisible();
+  const typeColrole = page.locator('text=Type').nth(1);
+  expect(await typeColrole.isVisible).toBeTruthy();
+
   
    //Screenshot
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  
 
 });
 
@@ -485,7 +519,7 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
   //Find Request
-  await page.getByRole('link', {name: serviceRequest}).click();
+  await page.getByRole('link', {name: requestId}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -282,33 +282,57 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   let secondPart = parts[1];
   console.log(firstPart, secondPart);
   requestId =secondPart;
+  let indicatorID;
+
+  const indicators = page.locator('[id^="loadingIndicator_"]');
  
+  const reviewer1Id = await indicators.nth(0).getAttribute('id');
+  const reviewer2Id = await indicators.nth(1).getAttribute('id');
+ 
+  console.log('Reviewer 1 ID:', reviewer1Id);
+  console.log('Reviewer 2 ID:', reviewer2Id);
+
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
+
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('userName:VTRHJHROSARIO');
 
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
+
+
+  const loadingInc = await page.locator(`#${reviewer2Id}`);
+  await expect(loadingInc).toBeVisible();
+  console.log('text', loadingInc);
+  await expect(loadingInc).not.toBeVisible();
+  //await page.locator(reviewer2Id).to
+
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
 
+ // const myLocator = page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' });
+//  myLocator.waitFor();
 
- // await expect(page.getByText('* Required')).not.toBeVisible();
+
+//await page.waitForSelector('searchbox', { name: 'Search for user to add as Reviewer 2' }).
+//console.log('Search results are visible!');/
+
  //Screenshot
-   const screenshot = await page.screenshot();
-  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+//   const screenshot = await page.screenshot();
+//  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
-    await expect(page.getByText('1. Reviewer')).toBeVisible();
-  await page.getByText('1. Reviewer').click();
-  await expect(page.locator('#save_indicator')).toBeVisible();
-  await page.locator('#save_indicator').click();
-
+ //await expect(page.getByText('*** Loading... ***',{ exact: true } )).toBeVisible();
+ //await expect(page.getByText('*** Loading... ***', { exact: true })).not.toBeVisible();
+  //await page.getByText('1. Reviewer').click();
+  //await expect(page.locator('#save_indicator')).toBeVisible();
+  //await page.locator('#save_indicator').click();
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
   
    //Submit Request
+   //await page.waitForSelector('#')
   await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Submit Request' }).click({force:true});
   await page.getByRole('link', { name: 'Home' }).click();
@@ -387,6 +411,15 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
   console.log(firstPart, secondPart);
   requestId2 =secondPart;
   
+  const indicators = page.locator('[id^="loadingIndicator_"]');
+ 
+  const reviewer1Id = await indicators.nth(0).getAttribute('id');
+  const reviewer2Id = await indicators.nth(1).getAttribute('id');
+ 
+  console.log('Reviewer 1 ID:', reviewer1Id);
+  console.log('Reviewer 2 ID:', reviewer2Id);
+
+
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('test');
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('test');
@@ -396,17 +429,22 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
 
+  const loadingInc = await page.locator(`#${reviewer2Id}`);
+  await expect(loadingInc).toBeVisible();
+  console.log('text', loadingInc);
+  await expect(loadingInc).not.toBeVisible();
+
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
+
+  const myLocator = page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' });
+  myLocator.waitFor();
 
  //Screenshot
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
-    await expect(page.getByText('1. Reviewer')).toBeVisible();
-  await page.getByText('1. Reviewer').click();
-  await expect(page.locator('#save_indicator')).toBeVisible();
-  await page.locator('#save_indicator').click();
+
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
@@ -493,6 +531,8 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await expect(page.getByText('New Request Start a new')).toBeVisible();
   await page.getByText('New Request Start a new').click();
 
+
+
   //Enter the required information
   await expect(page.getByRole('cell', { name: 'Select an Option Service' }).locator('a')).toBeVisible();
   await page.getByRole('cell', { name: 'Select an Option Service' }).locator('a').click();
@@ -506,6 +546,14 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   //Enter information for multipledesginated form
     await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
 
+        const indicators = page.locator('[id^="loadingIndicator_"]');
+ 
+  const reviewer1Id = await indicators.nth(0).getAttribute('id');
+  const reviewer2Id = await indicators.nth(1).getAttribute('id');
+ 
+  console.log('Reviewer 1 ID:', reviewer1Id);
+  console.log('Reviewer 2 ID:', reviewer2Id);
+
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
@@ -515,16 +563,25 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
  
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
+
+  const loadingInc = await page.locator(`#${reviewer2Id}`);
+  await expect(loadingInc).toBeVisible();
+  console.log('text', loadingInc);
+  await expect(loadingInc).not.toBeVisible();
+
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
+
+    const myLocator = page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' });
+  myLocator.waitFor();
 
  //Screenshot
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
-  await expect(page.getByText('1. Reviewer')).toBeVisible();
-  await page.getByText('1. Reviewer').click();
-  await expect(page.getByRole('button', { name: 'Previous Question' })).toBeVisible();
+
+
+
  
   await expect(page.locator('#nextQuestion')).toBeVisible();
  
@@ -683,5 +740,9 @@ test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
   await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
   await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
   await page.getByRole('button', { name: 'Delete Site' }).click();
+
+     //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
  });

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -286,15 +286,24 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('userName:VTRHJHROSARIO');
 
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
+
 
  // await expect(page.getByText('* Required')).not.toBeVisible();
  //Screenshot
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+    await expect(page.getByText('1. Reviewer')).toBeVisible();
+  await page.getByText('1. Reviewer').click();
+  await expect(page.locator('#save_indicator')).toBeVisible();
+  await page.locator('#save_indicator').click();
+
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -291,6 +291,7 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
 
+ // await expect(page.getByText('* Required')).not.toBeVisible();
  //Screenshot
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -19,8 +19,6 @@ let requestId;
 let requestId2
 let stapledRequestId;
 
-
-
 //Create Sitemap Card
 test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
@@ -72,8 +70,7 @@ test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
 
   //Verify display based on View
   //Form View
- 
-  await page.getByRole('button', { name: 'Toggle sections' }).click();
+   await page.getByRole('button', { name: 'Toggle sections' }).click();
   
   //Complex Form View
   const uidCol = page.locator('text=UID').nth(0);
@@ -101,6 +98,9 @@ test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
 
   const uidColrole = page.locator('text=UID').nth(0);
   expect(await uidColrole.isVisible()).toBeTruthy();
+
+  const typeColrole = page.locator('text=Type').nth(0);
+  expect(await typeColrole.isVisible).toBeTruthy();
 
   const serviceColrole = page.locator('text=Service').nth(2);
   expect(await serviceColrole.isVisible).toBeTruthy();
@@ -146,6 +146,9 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   const uidColrole = page.locator('text=UID').nth(0);
   expect(await uidColrole.isVisible()).toBeTruthy();
 
+    const typeColrole = page.locator('text=Type').nth(0);
+  expect(await typeColrole.isVisible).toBeTruthy();
+
   const serviceColrole = page.locator('text=Service').nth(2);
   expect(await serviceColrole.isVisible).toBeTruthy();
 
@@ -188,6 +191,12 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   const actionCol = page.locator('text=Action').nth(0);
   expect(await actionCol.isVisible).toBeTruthy();
 
+   const priorityCol = page.locator('text=Priority').nth(0);
+  expect(await priorityCol.isVisible).toBeTruthy();
+
+  const daysCol = page.locator('text=Days Since Last Action').nth(0);
+  expect(await daysCol.isVisible).toBeTruthy();
+
  });
 
 //Personalized a Form
@@ -222,7 +231,13 @@ test('Personalized a Form', async ({ page }, testInfo) => {
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
  
-  await page.getByRole('button', { name: 'Toggle sections' }).click();
+  //await page.getByRole('button', { name: 'Toggle sections' }).click();
+
+  const dynTxt2 = 'Multiple person designated View';
+  const dynRegex2 = new RegExp(`^${dynTxt2}.*`);
+
+  await page.getByRole('button', { name: dynRegex2}).click();
+
   const reviewCol = page.locator('text=Reviewer 1').nth(0);
   expect(await reviewCol.isVisible).toBeTruthy();
 
@@ -232,7 +247,6 @@ test('Personalized a Form', async ({ page }, testInfo) => {
   //Screenshot
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
 
 });
 
@@ -268,8 +282,7 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   let secondPart = parts[1];
   console.log(firstPart, secondPart);
   requestId =secondPart;
-  
-
+ 
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
@@ -285,8 +298,7 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
   
-  
-  //Submit Request
+   //Submit Request
   await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Submit Request' }).click({force:true});
   await page.getByRole('link', { name: 'Home' }).click();
@@ -312,20 +324,24 @@ test('View Request in Inbox', async ({ page }, testInfo) => {
   const dynRegex = new RegExp(`^${dynTxt}.*`);
   await page.getByRole('button', { name: dynRegex}).click();
  
-
  //Verify Text
  
   await expect(page.getByRole('cell', { name: requestId })).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'Adan Wolf' })).toBeVisible();
+ //await expect(page.getByRole('cell', { name: 'Adan Wolf' })).toBeVisible();
+  
+  const reviewCol = page.locator('text=Reviewer 1').nth(0);
+  expect(await reviewCol.isVisible).toBeTruthy();
+
+  const dateCol = page.locator('text=Date Submitted').nth(0);
+  expect(await dateCol.isVisible).toBeTruthy();
+
   const typeColrole = page.locator('text=Type').nth(1);
   expect(await typeColrole.isVisible).toBeTruthy();
 
-  
+ 
    //Screenshot
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
-
 
 });
 
@@ -350,7 +366,6 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
 
   //Enter the Reviewer Information
   await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
-
 
   //Get UID
   requestId2 = await page.textContent('#headerTab');
@@ -384,6 +399,7 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
   await page.getByRole('link', { name: 'Home' }).click();
 });
 
+//Verify custom column is not present when multiple forms are present in Role View
 test ('Validate Role View Custom Column not Present', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
@@ -396,7 +412,6 @@ test ('Validate Role View Custom Column not Present', async ({ page }, testInfo)
   await expect(page.getByRole('button', { name: 'Toggle sections' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
   
-
   //Select Tester
   const dynTxt = 'Tester Tester View';
   const dynRegex = new RegExp(`^${dynTxt}.*`);
@@ -404,16 +419,16 @@ test ('Validate Role View Custom Column not Present', async ({ page }, testInfo)
   const formRegex =new RegExp('^${formTxt}.*')
   
   await page.getByRole ('button', {name: dynRegex}).click();
+ 
+  await expect(page.getByRole('cell', { name: requestId2 })).toBeVisible();
   
- // NEED to add the form field await expect(page.getByRole('cell', { name: serviceRequest })).toBeVisible();
+  const typeColrole = page.locator('text=Type').nth(1);
+  expect(await typeColrole.isVisible).toBeTruthy();
 
-   await expect(page.getByRole('cell', { name: requestId2 })).toBeVisible();
    await expect(page.getByRole('columnheader', { name: 'Sort by Reviewer' })).not.toBeVisible();
 
-  // await expect(page.getByRole('cell', { name: 'Tester Tester' })).not.toBeVisible();
-
   //Screenshot
-   const screenshot = await page.screenshot();
+  const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
  
 });
@@ -442,8 +457,8 @@ test ('Create a Stapled Form', async ({ page }, testInfo) => {
 
    await expect(page.getByRole('button', { name: 'Test IFTHEN staple, stapled' })).toBeVisible();
   
-    //Screenshot
-   const screenshot = await page.screenshot();
+  //Screenshot
+  const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
  
   await page.getByRole('link', { name: 'Home' }).click();
@@ -453,9 +468,9 @@ test ('Create a Stapled Form', async ({ page }, testInfo) => {
 //Create a new Stapled Request
 test('Create a new Stapled Request', async ({ page }, testInfo) => {
 
-   await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
 
-   //Create a new stapled Request
+  //Create a new stapled Request
   await expect(page.getByText('New Request Start a new')).toBeVisible();
   await page.getByText('New Request Start a new').click();
 
@@ -506,7 +521,7 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
  await page.goto('https://host.docker.internal/Test_Request_Portal/');
 
-//Go to the Inbox
+  //Go to the Inbox
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
 
@@ -524,26 +539,23 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
   await expect(page.getByRole('button', { name: dynRegex })).toBeVisible();
   await page.getByRole('button', { name: dynRegex}).click();
- // await expect(page.locator('#LeafFormGrid805_970_type')).toContainText(stapleName);
+ 
   await expect(page.getByRole('cell', { name: stapleName })).toBeVisible();
+
+  const typeColrole = page.locator('text=Type').nth(1);
+  expect(await typeColrole.isVisible).toBeTruthy();
 
    //Screenshot
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
-  await expect(page.getByRole('button', { name: 'Organize by Forms' })).toBeVisible();
-  await page.getByRole('button', { name: 'Organize by Forms' }).click();
-  await expect(page.getByRole('button', { name: 'Multiple person designated' })).toBeVisible();
-  await page.getByRole('button', { name: 'Multiple person designated' }).click();
-
-  
+ 
 });
 
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
 
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
@@ -553,7 +565,6 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
   //Verify you want to Cancel Request
-
   await page.getByRole('dialog').getByText('Editor Close').click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
@@ -566,7 +577,7 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
 
 test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
 
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
@@ -576,7 +587,6 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
   //Verify you want to Cancel Request
-
   await page.getByRole('dialog').getByText('Editor Close').click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
@@ -589,22 +599,22 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
 
 test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
-  //Find Request
-  await page.getByRole('link', {name: stapledRequest}).click();
-  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
-  await page.getByRole('button', { name: 'Cancel Request' }).click();
+ //Find Request
+ await page.getByRole('link', {name: stapledRequest}).click();
+ await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
+ await page.getByRole('button', { name: 'Cancel Request' }).click();
 
-  //Verify you want to Cancel Request
+ //Verify you want to Cancel Request
 
-  await page.getByRole('dialog').getByText('Editor Close').click();
-  await page.getByRole('textbox', { name: 'Enter Comment' }).click();
-  await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
-  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
-  await page.getByRole('button', { name: 'Yes' }).click();
+ await page.getByRole('dialog').getByText('Editor Close').click();
+ await page.getByRole('textbox', { name: 'Enter Comment' }).click();
+ await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
+ await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
+ await page.getByRole('button', { name: 'Yes' }).click();
 
 });
 
@@ -647,7 +657,6 @@ test('Remove Stapled Forms', async ({ page }, testInfo) => {
   //Return Home
   await page.getByRole('link', { name: 'Home' }).click();
   
-
 });
 
 //Delete Customized Card

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -138,10 +138,23 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
   await expect(page.getByText(siteMapname, { exact: true })).toBeVisible();
 
+  //Get ID
+  const option =await (page.getByText('☰ LEAF 4832 - Customization'));
+ const siteId = await option.getAttribute('value');
+ const  leafSiteId = `#site-container-${siteId}`;
+
+  console.log('Text ID:', leafSiteId);
+ 
+
  //Add Customization
-  await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('p');
-  await page.getByRole('option', { name: 'Priority Press to select' }).click();
-  await page.getByRole('option', { name: 'Days Since Last Action Press' }).click();
+
+   await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('p');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('Enter');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('d');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('ArrowDown');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('ArrowDown');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('Enter');
 
   await page.getByRole('link', { name: 'Home' }).click();
   await expect(page.getByText('Review and apply actions to')).toBeVisible();
@@ -217,33 +230,37 @@ test('Personalized a Form', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
-    await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
   await page.getByRole('link', { name: 'Admin Panel' }).click();
   await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
   await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
   
+await page.waitForLoadState();
+
   await expect(page.getByText('☰ LEAF 4832 - Customization')).toBeVisible();
   
-await expect(page.getByLabel('Select a form to add specific')).toBeVisible();
- await page.getByLabel('Select a form to add specific').selectOption('form_f8b95');
+    //Get ID
+  const option =await (page.getByText('☰ LEAF 4832 - Customization'));
+ const siteId = await option.getAttribute('value');
+ const  leafSiteId = `#site-container-${siteId}`;
+ const formSiteId = `#form_select_${siteId}`;
 
-   await expect(page.getByRole('textbox', { name: 'Click to search. Limit 7' })).toBeVisible();
+  console.log('Text ID:', leafSiteId);
 
+  await expect(page.getByLabel('Select a form to add specific')).toBeVisible();
+  await page.locator(formSiteId).selectOption('form_f8b95');
 
-await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+ await page.locator(leafSiteId).getByText('StatusRemove item').click();
 
-//Add Reviewer 1 & Date Submitted
-  await page.getByRole('option', { name: 'Multiple person designated: Reviewer 1 (ID: 14) Press to select' }).click();
-  await page.getByRole('option', { name: 'Date Submitted Press to select' }).click();
-    //Remove Status
-  
-  await expect(page.getByText('StatusRemove item')).toBeVisible();
-  await page.getByRole('button', { name: 'Remove item: \'status\'' }).click();
-
-
-  //Verify the columns  
-
-  await expect(page.getByText('Multiple person designated (form_f8b95)Service, Title, id#14, Date Submitted')).toBeVisible();
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('d');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('ArrowDown');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('ArrowDown');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('ArrowDown');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('Enter');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('s');
+  await page.locator(leafSiteId).getByRole('textbox', { name: 'Click to search. Limit 7' }).press('Enter');
 
 
    //Check Inbox to verify updates
@@ -639,6 +656,8 @@ test('View Stapled Request', async ({ page }, testInfo) => {
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
 
+
+  await page.waitForLoadState();
   //Organize by Role to verify the stapled
   await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
@@ -747,6 +766,7 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
   //Find Request
+  await expect(page.locator('#searchContainer')).toBeVisible();
   await expect(page.getByRole('link', { name: requestId2})).toBeVisible();
   await page.getByRole('link', {name: requestId2}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
@@ -770,6 +790,7 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
  //Find Request
+ await expect(page.locator('#searchContainer')).toBeVisible();
  await expect(page.getByRole('link', { name: stapledRequestId})).toBeVisible();
  await page.getByRole('link', {name: stapledRequestId}).click();
  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { Dir } from 'fs';
 
 //This test is designed to test LEAF
 test.describe.configure({ mode: 'default' });
@@ -394,7 +395,7 @@ test('View Request in Inbox', async ({ page }, testInfo) => {
 
   await page.getByText('Review and apply actions to').click();
 
-  await page.waitForLoadState('load');
+  await page.waitForLoadState('domcontentloaded');
   await expect(page.locator('#inbox').getByText(siteMapname)).toBeVisible();
   await expect(page.getByRole('button', { name: 'View as Admin' })).toBeVisible();
   
@@ -497,8 +498,7 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
-  await page.waitForLoadState('load');
-  
+  await page.waitForLoadState('domcontentloaded');
   //Submit Request
   await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Submit Request' }).click({force:true});
@@ -706,51 +706,6 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
 test.describe('Clean up all test data', () =>{ 
 
-//Delete Customized Card
-
-test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-
-  await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
-
-  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
-  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
-  await page.getByRole('button', { name: 'Delete Site' }).click();
-
-     //Screenshot
-  const screenshot = await page.screenshot();
-  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
- });
-
-
-//Removed Stapled Forms
-test('Remove Stapled Forms', async ({ page }, testInfo) => {
-
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-
-   await page.waitForLoadState('load');
-
-  //Click on Form Editor
-  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
-  await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
-  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
-
-  //Find Multiple person designated Form
-  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
-  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
-
-  //Remove the stapled Form
-  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
-  await page.getByRole('button', { name: 'Staple other form' }).click();
-  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
-  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
-  await expect(page.getByText('Close')).toBeVisible();
-  await page.getByText('Close').click();
-  
-});
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
@@ -773,6 +728,7 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Yes' }).click();
 
 });
+
 
 //Cleanup Remove Request2
 
@@ -827,6 +783,55 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
  await page.getByRole('button', { name: 'Yes' }).click();
 
 });
+
+
+//Delete Customized Card
+
+test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
+
+  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
+  await page.getByRole('button', { name: 'Delete Site' }).click();
+
+     //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+ });
+
+
+//Removed Stapled Forms
+test('Remove Stapled Forms', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+   await page.waitForLoadState('load');
+
+  //Click on Form Editor
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
+  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
+
+  //Find Multiple person designated Form
+  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
+  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
+
+  //Remove the stapled Form
+  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
+  await page.getByRole('button', { name: 'Staple other form' }).click();
+  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
+  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
+  await expect(page.getByText('Close')).toBeVisible();
+  await page.getByText('Close').click();
+  
+});
+
+
 
 });
 

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -377,14 +377,18 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
   let secondPart = parts[1];
   console.log(firstPart, secondPart);
   requestId2 =secondPart;
-
+  
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('test');
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('test');
   await page.getByRole('cell', { name: 'Tester, Tester Product Liaison' }).click();
 
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toBeVisible();
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
+
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
 
  //Screenshot
    const screenshot = await page.screenshot();
@@ -490,10 +494,15 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('userName:VTRHJHROSARIO');
 
+
+ 
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
   await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
+
   await expect(page.locator('#nextQuestion')).toBeVisible();
  
  //Screenshot
@@ -619,8 +628,6 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
 });
 
-
-
 //Removed Stapled Forms
 test('Remove Stapled Forms', async ({ page }, testInfo) => {
 
@@ -643,20 +650,6 @@ test('Remove Stapled Forms', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
   await expect(page.getByText('Close')).toBeVisible();
   await page.getByText('Close').click();
-
-  //Verify stapled Fprm is removed
-  await expect(page.locator('#form_index_display')).toMatchAriaSnapshot(`
-    - status
-    - button "Preview this Form"
-    - button "Add Internal-Use"
-    - button "Staple other form"
-    - list:
-      - listitem:
-        - button "Multiple person designated, main form"
-    `);
-
-  //Return Home
-  await page.getByRole('link', { name: 'Home' }).click();
   
 });
 

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -403,6 +403,11 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
+    await expect(page.getByText('1. Reviewer')).toBeVisible();
+  await page.getByText('1. Reviewer').click();
+  await expect(page.locator('#save_indicator')).toBeVisible();
+  await page.locator('#save_indicator').click();
+
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
   
@@ -474,7 +479,7 @@ test ('Create a Stapled Form', async ({ page }, testInfo) => {
   //Screenshot
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
- 
+
   await page.getByRole('link', { name: 'Home' }).click();
 
 });
@@ -499,7 +504,8 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Click here to Proceed' }).click();
 
   //Enter information for multipledesginated form
-  await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
+    await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
+
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
   await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
@@ -512,12 +518,16 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' })).toHaveValue('userName:VTRXVPMADELAINE');
 
-  await expect(page.locator('#nextQuestion')).toBeVisible();
- 
  //Screenshot
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
+  await expect(page.getByText('1. Reviewer')).toBeVisible();
+  await page.getByText('1. Reviewer').click();
+  await expect(page.getByRole('button', { name: 'Previous Question' })).toBeVisible();
+ 
+  await expect(page.locator('#nextQuestion')).toBeVisible();
+ 
   const buttonClick = await page.getByRole('button', {name: 'Next Question'}).first();
   await buttonClick.click({force:true});
   

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 //This test is designed to test LEAF
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: 'default' });
 
 //Global Variables
 let randNum = Math.random();
@@ -19,7 +19,7 @@ let requestId;
 let requestId2
 let stapledRequestId;
 
-//Create Sitemap Card
+test.describe('SiteMap Creation, Verification and Inbox Customazation', () => {
 test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
@@ -250,6 +250,10 @@ test('Personalized a Form', async ({ page }, testInfo) => {
 
 });
 
+ });
+ //End of Creation and Customization
+
+test.describe('Creating and Validating Form Displays', () => {
 
 //Create a New MUltipleperson request
 test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
@@ -319,20 +323,17 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
 //console.log('Search results are visible!');/
 
  //Screenshot
-//   const screenshot = await page.screenshot();
-//  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
- //await expect(page.getByText('*** Loading... ***',{ exact: true } )).toBeVisible();
- //await expect(page.getByText('*** Loading... ***', { exact: true })).not.toBeVisible();
-  //await page.getByText('1. Reviewer').click();
-  //await expect(page.locator('#save_indicator')).toBeVisible();
-  //await page.locator('#save_indicator').click();
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
   
    //Submit Request
    //await page.waitForSelector('#')
+
+ page.waitForLoadState('domcontentloaded');
+
   await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Submit Request' }).click({force:true});
   await page.getByRole('link', { name: 'Home' }).click();
@@ -637,6 +638,13 @@ test('View Stapled Request', async ({ page }, testInfo) => {
  
 });
 
+});
+//End of Form Verification
+
+
+test.describe('Clean up all test data', () =>{ 
+
+
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
@@ -746,3 +754,6 @@ test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
  });
+
+});
+//End

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -688,6 +688,7 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
   await expect(page.getByRole('button', { name: dynRegex })).toBeVisible();
   await page.getByRole('button', { name: dynRegex}).click();
+  console.log('------------------------stapleName', stapleName);
  
   await expect(page.getByRole('cell', { name: stapleName })).toBeVisible();
 
@@ -716,17 +717,23 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
 
   //Find Request
   await expect(page.locator('#searchContainer')).toBeVisible();
-  await page.getByRole('link', {name: requestId}).click();
+  console.log('Request ID:>->->->->', requestId);
+  let staples = await page.locator("span.browsecounter").allInnerTexts();
+  let indexofStaple = staples.indexOf(requestId);
+  console.log('Index of Staple:', indexofStaple);
+  await page.locator("span.browsecounter a").nth(indexofStaple).click();
+    
+  // await page.getByRole('link', {name: requestId}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
-  //Verify you want to Cancel Request
+  // Verify you want to Cancel Request
   await page.getByRole('dialog').getByText('Editor Close').click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).click();
   await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
   await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
   await page.getByRole('button', { name: 'Yes' }).click();
-
+  
 });
 
 
@@ -742,8 +749,12 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
 
   //Find Request
   await expect(page.locator('#searchContainer')).toBeVisible();
-  await expect(page.getByRole('link', { name: requestId2})).toBeVisible();
-  await page.getByRole('link', {name: requestId2}).click();
+  let staples = await page.locator("span.browsecounter").allInnerTexts();
+  let indexofStaple = staples.indexOf(requestId2);
+  console.log('Index of Staple:', indexofStaple);
+  await page.locator("span.browsecounter a").nth(indexofStaple).click();
+  // await expect(page.getByRole('link', { name: requestId2})).toBeVisible();
+  // await page.getByRole('link', {name: requestId2}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
@@ -753,10 +764,10 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
   await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
   await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
   await page.getByRole('button', { name: 'Yes' }).click();
-
+  
 });
 
-//Cleanup Stapled Request
+// //Cleanup Stapled Request
 
 test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
@@ -769,8 +780,12 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
  //Find Request
  await expect(page.locator('#searchContainer')).toBeVisible();
- await expect(page.getByRole('link', { name: stapledRequestId})).toBeVisible();
- await page.getByRole('link', {name: stapledRequestId}).click();
+//  await expect(page.getByRole('link', { name: stapledRequestId})).toBeVisible();
+//  await page.getByRole('link', {name: stapledRequestId}).click();
+let staples = await page.locator("span.browsecounter").allInnerTexts();
+  let indexofStaple = staples.indexOf(stapledRequestId);
+  console.log('Index of Staple:', indexofStaple);
+  await page.locator("span.browsecounter a").nth(indexofStaple).click();
  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
  await page.getByRole('button', { name: 'Cancel Request' }).click();
 
@@ -781,11 +796,11 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
  await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
  await page.getByRole('button', { name: 'Yes' }).click();
-
+ 
 });
 
 
-//Delete Customized Card
+// //Delete Customized Card
 
 test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
@@ -804,7 +819,7 @@ test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
  });
 
 
-//Removed Stapled Forms
+// //Removed Stapled Forms
 test('Remove Stapled Forms', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/');

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -409,7 +409,7 @@ test ('Validate Role View Custom Column not Present', async ({ page }, testInfo)
   await page.getByText('Inbox').click();
 
   //Switch to Role View
-  await expect(page.getByRole('button', { name: 'Toggle sections' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
   
   //Select Tester

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -283,10 +283,10 @@ test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
   
-  //await expect(page.locator('#formcontent div').filter({ hasText: '1Reviewer 1 Adan Wolf' }).nth(1)).toBeVisible();
-
+  
   //Submit Request
-  await page.getByRole('button', { name: 'Submit Request' }).click();
+  await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
+  await page.getByRole('button', { name: 'Submit Request' }).click({force:true});
   await page.getByRole('link', { name: 'Home' }).click();
 
 
@@ -323,7 +323,7 @@ test('View Request in Inbox', async ({ page }, testInfo) => {
    const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
-  
+
 
 });
 
@@ -341,10 +341,8 @@ test('Verify Role View Custom Column not Present', async ({ page }, testInfo) =>
   await expect(page.getByRole('button', { name: 'Edit Reviewer 1 field' })).toBeVisible();
   await page.getByRole('button', { name: 'Edit Reviewer 1 field' }).click();
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).clear();
-  
-  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).click();
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('test');
-    await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('test');
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('test');
 
     await page.getByRole('cell', { name: 'Tester, Tester Product Liaison' }).click();
 
@@ -375,7 +373,7 @@ test('Verify Role View Custom Column not Present', async ({ page }, testInfo) =>
   
   await page.getByRole ('button', {name: dynRegex}).click();
   
-  await expect(page.getByRole('cell', { name: serviceRequest })).toBeVisible();
+ // NEED to add the form field await expect(page.getByRole('cell', { name: serviceRequest })).toBeVisible();
 
     await expect(page.getByLabel('LEAF 4832 - Request')).toMatchAriaSnapshot(`
     - cell /LEAF \\d+ - Request/:
@@ -383,7 +381,7 @@ test('Verify Role View Custom Column not Present', async ({ page }, testInfo) =>
       - button "Quick View"
     `);
   
-   await expect(page.getByRole('cell', { name: 'Tester Tester' })).not.toBeVisible();
+  // await expect(page.getByRole('cell', { name: 'Tester Tester' })).not.toBeVisible();
 
   //Screenshot
    const screenshot = await page.screenshot();

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -4,7 +4,6 @@ import { test, expect } from '@playwright/test';
 test.describe.configure({ mode: 'default' });
 
 //Global Variables
-let randNum = Math.random();
 let siteMapname = `LEAF 4832 - Customization`;
 let siteMapDesc = 'Testing for LEAF 4823 Customization';
 let leafSiteCard = 'LEAF 4832 - CustomizationTesting for LEAF 4823 Customization';
@@ -672,6 +671,24 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
 test.describe('Clean up all test data', () =>{ 
 
+//Delete Customized Card
+
+test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
+
+  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
+  await page.getByRole('button', { name: 'Delete Site' }).click();
+
+     //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+ });
+
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
@@ -681,7 +698,7 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
   //Find Request
-  await expect(page.getByRole('link', { name: requestId})).toBeVisible();
+  await expect(page.locator('#searchContainer')).toBeVisible();
   await page.getByRole('link', {name: requestId}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
@@ -693,6 +710,32 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
   await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
   await page.getByRole('button', { name: 'Yes' }).click();
 
+});
+
+
+//Removed Stapled Forms
+test('Remove Stapled Forms', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  //Click on Form Editor
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
+  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
+
+  //Find Multiple person designated Form
+  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
+  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
+
+  //Remove the stapled Form
+  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
+  await page.getByRole('button', { name: 'Staple other form' }).click();
+  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
+  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
+  await expect(page.getByText('Close')).toBeVisible();
+  await page.getByText('Close').click();
+  
 });
 
 //Cleanup Remove Request2
@@ -741,49 +784,6 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
  await page.getByRole('button', { name: 'Yes' }).click();
 
 });
-
-//Removed Stapled Forms
-test('Remove Stapled Forms', async ({ page }, testInfo) => {
-
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-
-  //Click on Form Editor
-  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
-  await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
-  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
-
-  //Find Multiple person designated Form
-  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
-  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
-
-  //Remove the stapled Form
-  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
-  await page.getByRole('button', { name: 'Staple other form' }).click();
-  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
-  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
-  await expect(page.getByText('Close')).toBeVisible();
-  await page.getByText('Close').click();
-  
-});
-
-//Delete Customized Card
-
-test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-
-  await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
-
-  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
-  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
-  await page.getByRole('button', { name: 'Delete Site' }).click();
-
-     //Screenshot
-  const screenshot = await page.screenshot();
-  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
-
- });
 
 });
 

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -7,9 +7,7 @@ test.describe.configure({ mode: 'default' });
 let siteMapname = `LEAF 4832 - Customization`;
 let siteMapDesc = 'Testing for LEAF 4823 Customization';
 let leafSiteCard = 'LEAF 4832 - CustomizationTesting for LEAF 4823 Customization';
-let siteMapURL = 'https://host.docker.internal/Test_Request_Portal/';
-let siteMapColor = '#5d1adb';
-let siteMapFontColor = '#e2db08';
+
 let serviceRequest ='LEAF 4832 - Request';
 let serviceRequest2 ='LEAF 4832 - Request2';
 let stapledRequest = 'LEAF 4832 - Stapled Request';
@@ -42,6 +40,9 @@ test('create New Sitemap Card', async ({ page }, testInfo) => {
   
 
   //Style the Sitemap
+  let siteMapURL = 'https://host.docker.internal/Test_Request_Portal/';
+  let siteMapColor = '#5d1adb';
+  let siteMapFontColor = '#e2db08';
   await page.getByRole('button', { name: '+ Add Site' }).click();
   await page.locator('#button-title').click();
   await page.locator('#button-title').fill(siteMapname);
@@ -75,6 +76,8 @@ test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
   //Open the Inbox
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
+
+  await page.waitForLoadState('load');
 
   //Verify the customization is present 
   await expect(page.locator('#inbox').getByText(siteMapname)).toBeVisible();
@@ -136,6 +139,8 @@ test('Customized Column Display', async ({ page }, testInfo) => {
   await page.getByRole('link', { name: 'Admin Panel' }).click();
   await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
   await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
+
+   await page.waitForLoadState('load');
   await expect(page.getByText(siteMapname, { exact: true })).toBeVisible();
 
   //Get ID
@@ -158,6 +163,8 @@ test('Customized Column Display', async ({ page }, testInfo) => {
 
   await page.getByRole('link', { name: 'Home' }).click();
   await expect(page.getByText('Review and apply actions to')).toBeVisible();
+
+   await page.waitForLoadState('load');
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
 
@@ -247,7 +254,7 @@ await page.waitForLoadState();
 
   console.log('Text ID:', leafSiteId);
 
-  await expect(page.getByLabel('Select a form to add specific')).toBeVisible();
+
   await page.locator(formSiteId).selectOption('form_f8b95');
 
  await page.locator(leafSiteId).getByText('StatusRemove item').click();
@@ -270,6 +277,7 @@ await page.waitForLoadState();
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox Review and apply').click();
  
+ await page.waitForLoadState('load');
   //await page.getByRole('button', { name: 'Toggle sections' }).click();
 
   const dynTxt2 = 'Multiple person designated View';
@@ -386,6 +394,7 @@ test('View Request in Inbox', async ({ page }, testInfo) => {
 
   await page.getByText('Review and apply actions to').click();
 
+  await page.waitForLoadState('load');
   await expect(page.locator('#inbox').getByText(siteMapname)).toBeVisible();
   await expect(page.getByRole('button', { name: 'View as Admin' })).toBeVisible();
   
@@ -488,7 +497,7 @@ test('Create Multiple Form with User with multiple Forms', async ({ page }, test
 
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
-  
+  await page.waitForLoadState('load');
   
   //Submit Request
   await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
@@ -504,6 +513,8 @@ test ('Validate Role View Custom Column not Present', async ({ page }, testInfo)
   //Go to the Custom Inbox
   await expect(page.getByText('Inbox Review and apply')).toBeVisible();
   await page.getByText('Inbox').click();
+
+   await page.waitForLoadState('load');
 
   //Switch to Role View
   await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
@@ -571,7 +582,7 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await expect(page.getByText('New Request Start a new')).toBeVisible();
   await page.getByText('New Request Start a new').click();
 
-
+  await page.waitForLoadState('load');
 
   //Enter the required information
   await expect(page.getByRole('cell', { name: 'Select an Option Service' }).locator('a')).toBeVisible();
@@ -582,6 +593,8 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await page.locator('label').filter({ hasText: 'Multiple person designated' }).locator('span').click();
   await expect(page.getByRole('button', { name: 'Click here to Proceed' })).toBeVisible();
   await page.getByRole('button', { name: 'Click here to Proceed' }).click();
+
+  await page.waitForLoadState('load');
 
   //Enter information for multipledesginated form
   await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
@@ -633,12 +646,15 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   const buttonClick = await page.getByRole('button', {name: 'Next Question'}).first();
   await buttonClick.click({force:true});
   
+  await page.waitForLoadState('load');
  //Enter information for If then Form
   await expect(page.locator('a').filter({ hasText: 'Select an Option' })).toBeVisible();
   await page.locator('a').filter({ hasText: 'Select an Option' }).click();
   await page.getByRole('option', { name: '2' }).click();
   await expect(page.locator('#nextQuestion2')).toBeVisible();
   await page.locator('#nextQuestion2').click({force:true});
+
+ await page.waitForLoadState('load');
 
    //Submit Request
   await expect(page.locator('#submitControl')).toBeVisible();
@@ -657,7 +673,7 @@ test('View Stapled Request', async ({ page }, testInfo) => {
   await page.getByText('Inbox Review and apply').click();
 
 
-  await page.waitForLoadState();
+  await page.waitForLoadState('domcontentloaded');
   //Organize by Role to verify the stapled
   await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
   await page.getByRole('button', { name: 'Organize by Roles' }).click();
@@ -708,6 +724,33 @@ test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
 
  });
 
+
+//Removed Stapled Forms
+test('Remove Stapled Forms', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+   await page.waitForLoadState('load');
+
+  //Click on Form Editor
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
+  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
+
+  //Find Multiple person designated Form
+  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
+  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
+
+  //Remove the stapled Form
+  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
+  await page.getByRole('button', { name: 'Staple other form' }).click();
+  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
+  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
+  await expect(page.getByText('Close')).toBeVisible();
+  await page.getByText('Close').click();
+  
+});
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
@@ -731,39 +774,15 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
 
 });
 
-
-//Removed Stapled Forms
-test('Remove Stapled Forms', async ({ page }, testInfo) => {
-
-  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-
-  //Click on Form Editor
-  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
-  await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
-  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
-
-  //Find Multiple person designated Form
-  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
-  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
-
-  //Remove the stapled Form
-  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
-  await page.getByRole('button', { name: 'Staple other form' }).click();
-  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
-  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
-  await expect(page.getByText('Close')).toBeVisible();
-  await page.getByText('Close').click();
-  
-});
-
 //Cleanup Remove Request2
 
 test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
 
  await page.goto('https://host.docker.internal/Test_Request_Portal/');
-  
+
+  await page.waitForLoadState('domcontentloaded');
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  
 
   //Find Request
   await expect(page.locator('#searchContainer')).toBeVisible();
@@ -786,8 +805,11 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
 test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  await page.waitForLoadState('load');
   
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+
 
  //Find Request
  await expect(page.locator('#searchContainer')).toBeVisible();

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -19,6 +19,7 @@ let requestId;
 let requestId2
 let stapledRequestId;
 
+
 test.describe('SiteMap Creation, Verification and Inbox Customazation', () => {
 test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
@@ -27,6 +28,19 @@ test('create New Sitemap Card', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
 
   await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+
+
+ //Check to see if Custom LEAF Sitemap is present
+  if ( await page.getByText(leafSiteCard).isVisible() ){
+    //Perform Cleanup
+  console.log("Cleanup");
+  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
+  await page.getByRole('button', { name: 'Delete Site' }).click();
+
+  } 
+    console.log ("Sitemap not present");
+  
 
   //Style the Sitemap
   await page.getByRole('button', { name: '+ Add Site' }).click();
@@ -204,25 +218,34 @@ test('Personalized a Form', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
   
+    await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
   await page.getByRole('link', { name: 'Admin Panel' }).click();
-  await page.getByRole('button', { name: 'admin submenu' }).click();
   await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
   await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
   
-  await expect(page.getByText('LEAF 4832 - CustomizationUIDServiceTitleStatusPriorityDays Since Last')).toBeVisible();
+  await expect(page.getByText('☰ LEAF 4832 - Customization')).toBeVisible();
   
-  await page.getByLabel('Select a form to add specific').selectOption('form_f8b95');
-  await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+await expect(page.getByLabel('Select a form to add specific')).toBeVisible();
+ await page.getByLabel('Select a form to add specific').selectOption('form_f8b95');
 
-  //Add Reviewer 1 & Date Submitted
+   await expect(page.getByRole('textbox', { name: 'Click to search. Limit 7' })).toBeVisible();
+
+
+await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+
+//Add Reviewer 1 & Date Submitted
   await page.getByRole('option', { name: 'Multiple person designated: Reviewer 1 (ID: 14) Press to select' }).click();
   await page.getByRole('option', { name: 'Date Submitted Press to select' }).click();
-
-  //Remove Status
+    //Remove Status
+  
+  await expect(page.getByText('StatusRemove item')).toBeVisible();
   await page.getByRole('button', { name: 'Remove item: \'status\'' }).click();
 
+
   //Verify the columns  
+
   await expect(page.getByText('Multiple person designated (form_f8b95)Service, Title, id#14, Date Submitted')).toBeVisible();
+
 
    //Check Inbox to verify updates
   await page.getByRole('link', { name: 'Home' }).click();
@@ -545,15 +568,24 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Click here to Proceed' }).click();
 
   //Enter information for multipledesginated form
-    await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toBeVisible();
 
-        const indicators = page.locator('[id^="loadingIndicator_"]');
- 
+  const indicators = page.locator('[id^="loadingIndicator_"]');
   const reviewer1Id = await indicators.nth(0).getAttribute('id');
   const reviewer2Id = await indicators.nth(1).getAttribute('id');
  
   console.log('Reviewer 1 ID:', reviewer1Id);
   console.log('Reviewer 2 ID:', reviewer2Id);
+
+  //Get UID
+  stapledRequestId = await page.textContent('#headerTab');
+  console.log('Text inside span:', stapledRequestId);
+  let str: string = stapledRequestId;
+  let parts = str.split("#", 2);
+  let firstPart = parts[0];
+  let secondPart = parts[1];
+  console.log(firstPart, secondPart);
+  stapledRequestId =secondPart;
 
   await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
   await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
@@ -580,10 +612,6 @@ test('Create a new Stapled Request', async ({ page }, testInfo) => {
   const screenshot = await page.screenshot();
   await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
 
-
-
-
- 
   await expect(page.locator('#nextQuestion')).toBeVisible();
  
   const buttonClick = await page.getByRole('button', {name: 'Next Question'}).first();
@@ -644,7 +672,6 @@ test('View Stapled Request', async ({ page }, testInfo) => {
 
 test.describe('Clean up all test data', () =>{ 
 
-
 //Cleanup Remove Request
 
 test('Clean up NewRequest Form', async ({ page }, testInfo) => {
@@ -654,6 +681,7 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
   //Find Request
+  await expect(page.getByRole('link', { name: requestId})).toBeVisible();
   await page.getByRole('link', {name: requestId}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
@@ -676,6 +704,7 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
   //Find Request
+  await expect(page.getByRole('link', { name: requestId2})).toBeVisible();
   await page.getByRole('link', {name: requestId2}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
@@ -698,7 +727,8 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
 
  //Find Request
- await page.getByRole('link', {name: stapledRequest}).click();
+ await expect(page.getByRole('link', { name: stapledRequestId})).toBeVisible();
+ await page.getByRole('link', {name: stapledRequestId}).click();
  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
  await page.getByRole('button', { name: 'Cancel Request' }).click();
 
@@ -756,4 +786,5 @@ test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
  });
 
 });
+
 //End

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { Dir } from 'fs';
 
 //This test is designed to test LEAF
 test.describe.configure({ mode: 'default' });
@@ -717,13 +716,9 @@ test('Clean up NewRequest Form', async ({ page }, testInfo) => {
 
   //Find Request
   await expect(page.locator('#searchContainer')).toBeVisible();
-  console.log('Request ID:>->->->->', requestId);
   let staples = await page.locator("span.browsecounter").allInnerTexts();
   let indexofStaple = staples.indexOf(requestId);
-  console.log('Index of Staple:', indexofStaple);
   await page.locator("span.browsecounter a").nth(indexofStaple).click();
-    
-  // await page.getByRole('link', {name: requestId}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
@@ -751,10 +746,7 @@ test('Clean up NewRequest Form2', async ({ page }, testInfo) => {
   await expect(page.locator('#searchContainer')).toBeVisible();
   let staples = await page.locator("span.browsecounter").allInnerTexts();
   let indexofStaple = staples.indexOf(requestId2);
-  console.log('Index of Staple:', indexofStaple);
   await page.locator("span.browsecounter a").nth(indexofStaple).click();
-  // await expect(page.getByRole('link', { name: requestId2})).toBeVisible();
-  // await page.getByRole('link', {name: requestId2}).click();
   await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
   await page.getByRole('button', { name: 'Cancel Request' }).click();
 
@@ -780,11 +772,8 @@ test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
 
  //Find Request
  await expect(page.locator('#searchContainer')).toBeVisible();
-//  await expect(page.getByRole('link', { name: stapledRequestId})).toBeVisible();
-//  await page.getByRole('link', {name: stapledRequestId}).click();
 let staples = await page.locator("span.browsecounter").allInnerTexts();
   let indexofStaple = staples.indexOf(stapledRequestId);
-  console.log('Index of Staple:', indexofStaple);
   await page.locator("span.browsecounter a").nth(indexofStaple).click();
  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
  await page.getByRole('button', { name: 'Cancel Request' }).click();

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -1,0 +1,577 @@
+import { test, expect } from '@playwright/test';
+
+//This test is designed to test LEAF
+test.describe.configure({ mode: 'serial' });
+
+//Global Variables
+let siteMapname = 'LEAF 4832 - Customization';
+let siteMapDesc = 'Testing for LEAF 4823 Customization';
+let siteMapURL = 'https://host.docker.internal/Test_Request_Portal/';
+let siteMapColor = '#5d1adb';
+let siteMapFontColor = '#e2db08';
+let serviceRequest ='LEAF 4832 - Request';
+let stapledRequest = 'LEAF 4832 - Stapled Request';
+let stapleName = 'Test IFTHEN staple | Multiple person designated';
+
+
+
+//Create Sitemap Card
+test('create New Sitemap Card', async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
+
+  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+  await page.getByRole('button', { name: '+ Add Site' }).click();
+  await page.locator('#button-title').click();
+  await page.locator('#button-title').fill(siteMapname);
+  await page.getByRole('textbox', { name: 'Enter group name' }).click();
+  await page.getByRole('textbox', { name: 'Enter group name' }).fill(siteMapDesc);
+  await page.locator('#button-target').click();
+  await page.locator('#button-target').click();
+  await page.locator('#button-target').fill(siteMapURL);
+  await page.locator('input[name="btnColor"]').click();
+  await page.locator('input[name="btnColor"]').fill(siteMapColor);
+  await page.locator('input[name="btnFntColor"]').click();
+  await page.locator('input[name="btnFntColor"]').fill(siteMapFontColor);
+  await page.locator('#xhr').click();
+  await page.getByRole('img', { name: 'application-x-executable.svg' }).click();
+  await page.getByRole('button', { name: 'Save Change' }).click();
+
+  //Verify the customized card is present
+  await expect(page.getByText('LEAF 4832 - CustomizationTesting for LEAF 4823 Customization')).toBeVisible();
+ 
+  //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+});
+
+//Inbox before Customization
+test('Display Inbox Sitemap Personalization', async ({ page }, testInfo) => {
+
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
+  //Open the Inbox
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByText('Inbox Review and apply').click();
+
+  //Verify the customization is present 
+  await expect(page.locator('#inbox').getByText('LEAF 4832 - Customization')).toBeVisible();
+  await expect(page.locator('#indexSites')).toContainText('LEAF 4832 - Customization');
+
+
+  //Verify display based on View
+  //Form View
+ 
+  await page.getByRole('button', { name: 'Toggle sections' }).click();
+  
+  //Complex Form View
+  const uidCol = page.locator('text=UID').nth(0);
+  expect(await uidCol.isVisible()).toBeTruthy();
+
+  const serviceCol = page.locator('text=Service').nth(0);
+  expect(await serviceCol.isVisible).toBeTruthy();
+
+  const titleCol = page.locator('text=Title').nth(0);
+  expect(await titleCol.isVisible).toBeTruthy();
+
+  const statusCol = page.locator('text=Status').nth(0);
+  expect(await statusCol.isVisible).toBeTruthy();
+
+  const actionCol = page.locator('text=Action').nth(0);
+  expect(await actionCol.isVisible).toBeTruthy();
+
+   //Role View
+   await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
+  await page.getByRole('button', { name: 'Organize by Roles' }).click();
+  await page.getByRole('button', { name: 'Toggle sections' }).click();
+    const uidColrole = page.locator('text=UID').nth(0);
+  expect(await uidColrole.isVisible()).toBeTruthy();
+
+  const serviceColrole = page.locator('text=Service').nth(1);
+  expect(await serviceColrole.isVisible).toBeTruthy();
+
+  const titleColrole = page.locator('text=Title').nth(0);
+  expect(await titleColrole.isVisible).toBeTruthy();
+
+  const statusColrole = page.locator('text=Status').nth(0);
+  expect(await statusColrole.isVisible).toBeTruthy();
+
+  const actionColrole = page.locator('text=Action').nth(0);
+  expect(await actionColrole.isVisible).toBeTruthy();
+
+
+});
+//Add additional customization
+test('Customized Column Display', async ({ page }, testInfo) => {
+
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
+  await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
+  await expect(page.getByText('LEAF 4832 - Customization', { exact: true })).toBeVisible();
+
+ //Add Customization
+  await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).fill('p');
+  await page.getByRole('option', { name: 'Priority Press to select' }).click();
+  await page.getByRole('option', { name: 'Days Since Last Action Press' }).click();
+
+  await page.getByRole('link', { name: 'Home' }).click();
+  await expect(page.getByText('Review and apply actions to')).toBeVisible();
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByText('Inbox Review and apply').click();
+
+  await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
+  await page.getByRole('button', { name: 'Organize by Roles' }).click();
+
+  await expect(page.getByRole('button', { name: 'Toggle sections' })).toBeVisible();
+  await page.getByRole('button', { name: 'Toggle sections' }).click();
+
+  //Verify Role Customization
+  const uidColrole = page.locator('text=UID').nth(0);
+  expect(await uidColrole.isVisible()).toBeTruthy();
+
+  const serviceColrole = page.locator('text=Service').nth(1);
+  expect(await serviceColrole.isVisible).toBeTruthy();
+
+  const titleColrole = page.locator('text=Title').nth(0);
+  expect(await titleColrole.isVisible).toBeTruthy();
+
+  const statusColrole = page.locator('text=Status').nth(0);
+  expect(await statusColrole.isVisible).toBeTruthy();
+
+  const actionColrole = page.locator('text=Action').nth(0);
+  expect(await actionColrole.isVisible).toBeTruthy();
+
+  const priorityColrole = page.locator('text=Priority').nth(0);
+  expect(await priorityColrole.isVisible).toBeTruthy();
+
+  const daysColrole = page.locator('text=Days Since Last Action').nth(0);
+  expect(await daysColrole.isVisible).toBeTruthy();
+
+
+ //Form View
+  await page.getByRole('button', { name: 'Organize by Forms' }).click();
+  await page.getByRole('button', { name: 'Toggle sections' }).click();
+  
+  //Complex Form View
+  const uidCol = page.locator('text=UID').nth(0);
+  expect(await uidCol.isVisible()).toBeTruthy();
+
+  const serviceCol = page.locator('text=Service').nth(0);
+  expect(await serviceCol.isVisible).toBeTruthy();
+
+  const titleCol = page.locator('text=Title').nth(0);
+  expect(await titleCol.isVisible).toBeTruthy();
+
+  const statusCol = page.locator('text=Status').nth(0);
+  expect(await statusCol.isVisible).toBeTruthy();
+
+  const actionCol = page.locator('text=Action').nth(0);
+  expect(await actionCol.isVisible).toBeTruthy();
+
+ });
+
+//Personalized a Form
+test('Personalized a Form', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await page.getByRole('button', { name: 'admin submenu' }).click();
+  await expect(page.getByRole('button', { name: ' Combined Inbox Editor Edit' })).toBeVisible();
+  await page.getByRole('button', { name: ' Combined Inbox Editor Edit' }).click();
+  
+  await expect(page.getByText('LEAF 4832 - CustomizationUIDServiceTitleStatusPriorityDays Since Last')).toBeVisible();
+  
+  await page.getByLabel('Select a form to add specific').selectOption('form_f8b95');
+  await page.getByRole('textbox', { name: 'Click to search. Limit 7' }).click();
+
+  //Add Reviewer 1 & Date Submitted
+  await page.getByRole('option', { name: 'Multiple person designated: Reviewer 1 (ID: 14) Press to select' }).click();
+  await page.getByRole('option', { name: 'Date Submitted Press to select' }).click();
+
+  //Remove Status
+  await page.getByRole('button', { name: 'Remove item: \'status\'' }).click();
+
+  //Verify the columns  
+  await expect(page.getByText('Multiple person designated (form_f8b95)Service, Title, id#14, Date Submitted')).toBeVisible();
+
+   //Check Inbox to verify updates
+  await page.getByRole('link', { name: 'Home' }).click();
+
+  //Open the Inbox
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByText('Inbox Review and apply').click();
+ 
+  await page.getByRole('button', { name: 'Toggle sections' }).click();
+  const reviewCol = page.locator('text=Reviewer 1').nth(0);
+  expect(await reviewCol.isVisible).toBeTruthy();
+
+  const dateCol = page.locator('text=Date Submitted').nth(0);
+  expect(await dateCol.isVisible).toBeTruthy();
+
+  //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+
+});
+
+
+//Create a New MUltipleperson request
+test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  //Start a new Multiple person designated
+  await page.getByText('New Request Start a new').click();
+
+  //Enter data needed to create Request
+  await expect(page.getByRole('heading', { name: 'Step 1 - General Information' })).toBeVisible();
+  await page.getByRole('cell', { name: 'Select an Option Service' }).locator('a').click();
+  await page.getByRole('option', { name: 'AS - Service' }).click();
+  await page.getByText('Please enter keywords to').click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).fill(serviceRequest);
+  await page.locator('label').filter({ hasText: 'Multiple person designated' }).locator('span').click();
+
+  await page.getByRole('button', { name: 'Click here to Proceed' }).click();
+
+  //Enter the Reviewer Information
+  await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
+
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
+  await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
+  await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
+
+    await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
+  await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
+  await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
+
+ //Screenshot
+   const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  await expect(page.locator('#nextQuestion2')).toBeVisible();
+  await page.locator('#nextQuestion2').click({force:true});
+  
+  //await expect(page.locator('#formcontent div').filter({ hasText: '1Reviewer 1 Adan Wolf' }).nth(1)).toBeVisible();
+
+  //Submit Request
+  await page.getByRole('button', { name: 'Submit Request' }).click();
+  await page.getByRole('link', { name: 'Home' }).click();
+
+
+});
+
+test('View Request in Inbox', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  await page.getByText('Review and apply actions to').click();
+
+  await expect(page.locator('#inbox').getByText('LEAF 4832 - Customization')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'View as Admin' })).toBeVisible();
+  
+
+ // await page.getByRole('button', {name:'Multiple person designated'}).click();
+  await page.getByRole('button', { name: 'Organize by Roles' }).click();
+  await page.getByRole('button', { name: 'View as Admin' }).click();
+  await page.getByRole('button', { name: 'Adan Wolf View 1 requests' }).click();
+
+ //Verify Text
+ 
+  await expect(page.getByRole('cell', { name: 'Multiple person designated' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'LEAF 4832 - Request' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'Adan Wolf' })).toBeVisible();
+  
+   //Screenshot
+   const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+});
+
+//Verify custom form columns should show if there is only one form type in the section.
+test('Verify Role View Custom Column not Present', async ({ page }, testInfo) => {
+
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+
+ //Select the request
+  await expect(page.getByRole('link', { name: serviceRequest})).toBeVisible();
+  await page.getByRole('link', { name: serviceRequest }).click();
+
+  //Update Request
+  await expect(page.getByRole('button', { name: 'Edit Reviewer 1 field' })).toBeVisible();
+  await page.getByRole('button', { name: 'Edit Reviewer 1 field' }).click();
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).clear();
+  
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).click();
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('test');
+    await expect(page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' })).toHaveValue('test');
+
+    await page.getByRole('cell', { name: 'Tester, Tester Product Liaison' }).click();
+
+ // await expect(page.getByText('NameLocationContact Tester,')).toBeVisible();
+
+  //Save updated Request
+  await expect(page.getByRole('button', { name: 'Save Change' })).toBeVisible();
+  await page.getByRole('button', { name: 'Save Change' }).click();
+
+  //Return to the homepage
+  await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  await page.getByRole('link', { name: 'Home' }).click();
+
+  //Go to the Custom Inbox
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByText('Inbox').click();
+
+  //Switch to Role View
+  await expect(page.getByRole('button', { name: 'Toggle sections' })).toBeVisible();
+  await page.getByRole('button', { name: 'Organize by Roles' }).click();
+  
+
+  //Select Tester
+  const dynTxt = 'Tester Tester View';
+  const dynRegex = new RegExp(`^${dynTxt}.*`);
+  const formTxt = 'LeafFormGrid';
+  const formRegex =new RegExp('^${formTxt}.*')
+  
+  await page.getByRole ('button', {name: dynRegex}).click();
+  
+  await expect(page.getByRole('cell', { name: serviceRequest })).toBeVisible();
+
+    await expect(page.getByLabel('LEAF 4832 - Request')).toMatchAriaSnapshot(`
+    - cell /LEAF \\d+ - Request/:
+      - link /LEAF \\d+ - Request/
+      - button "Quick View"
+    `);
+  
+   await expect(page.getByRole('cell', { name: 'Tester Tester' })).not.toBeVisible();
+
+  //Screenshot
+   const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+ 
+});
+
+//Create a Stapled Form
+test ('Create a Stapled Form', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+ 
+ 
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+
+  //Staple Form
+  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
+  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
+  await page.getByRole('button', { name: 'Staple other form' }).click();
+
+  //Add and Verify the Staples
+  await page.getByLabel('Select a form to merge').selectOption('form_dac2a');
+  await expect(page.locator('#leaf_dialog_content_drag_handle')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Add', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+  await page.getByText('Close').click();
+
+   await expect(page.getByRole('button', { name: 'Test IFTHEN staple, stapled' })).toBeVisible();
+  
+    //Screenshot
+   const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+ 
+  await page.getByRole('link', { name: 'Home' }).click();
+
+});
+
+//Create a new Stapled Request
+test('Create a new Stapled Request', async ({ page }, testInfo) => {
+
+   await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+   //Create a new stapled Request
+  await expect(page.getByText('New Request Start a new')).toBeVisible();
+  await page.getByText('New Request Start a new').click();
+
+  //Enter the required information
+  await expect(page.getByRole('cell', { name: 'Select an Option Service' }).locator('a')).toBeVisible();
+  await page.getByRole('cell', { name: 'Select an Option Service' }).locator('a').click();
+  await page.getByRole('option', { name: 'AS - Service' }).click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).fill(stapledRequest);
+  await page.locator('label').filter({ hasText: 'Multiple person designated' }).locator('span').click();
+  await expect(page.getByRole('button', { name: 'Click here to Proceed' })).toBeVisible();
+  await page.getByRole('button', { name: 'Click here to Proceed' }).click();
+
+  //Enter information for multipledesginated form
+  await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 1' }).fill('ad');
+  await page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' }).click();
+  await expect(page.getByRole('cell', { name: 'Wolf, Adan Williamson. Direct' })).toBeVisible();
+
+  await page.getByRole('searchbox', { name: 'Search for user to add as Reviewer 2' }).fill('h');
+  await page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' }).click();
+  await expect(page.getByRole('cell', { name: 'Hackett, Linsey Spinka.' })).toBeVisible();
+  await expect(page.locator('#nextQuestion')).toBeVisible();
+ 
+ //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  const buttonClick = await page.getByRole('button', {name: 'Next Question'}).first();
+  await buttonClick.click({force:true});
+  
+ //Enter information for If then Form
+  await expect(page.locator('a').filter({ hasText: 'Select an Option' })).toBeVisible();
+  await page.locator('a').filter({ hasText: 'Select an Option' }).click();
+  await page.getByRole('option', { name: '2' }).click();
+  await expect(page.locator('#nextQuestion2')).toBeVisible();
+  await page.locator('#nextQuestion2').click({force:true});
+
+   //Submit Request
+  await expect(page.locator('#submitControl')).toBeVisible();
+  await page.getByRole('button', { name: 'Submit Request' }).click();
+  await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  await page.getByRole('link', { name: 'Home' }).click();
+});
+
+//View Stapled Form
+test('View Stapled Request', async ({ page }, testInfo) => {
+
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+//Go to the Inbox
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByText('Inbox Review and apply').click();
+
+  //Organize by Role to verify the stapled
+  await expect(page.getByRole('button', { name: 'Organize by Roles' })).toBeVisible();
+  await page.getByRole('button', { name: 'Organize by Roles' }).click();
+  await expect(page.getByRole('button', { name: 'View as Admin' })).toBeVisible();
+  await page.getByRole('button', { name: 'View as Admin' }).click();
+
+  //Verify Stapled 
+  const formTxt = 'LeafFormGrid';
+  const formRegex =new RegExp('^${formTxt}.*')
+
+  await expect(page.getByRole('button', { name: 'Adan Wolf View 1 requests' })).toBeVisible();
+  await page.getByRole('button', { name: 'Adan Wolf View 1 requests' }).click();
+ // await expect(page.locator('#LeafFormGrid805_970_type')).toContainText(stapleName);
+  await expect(page.getByRole('cell', { name: stapleName })).toBeVisible();
+
+   //Screenshot
+  const screenshot = await page.screenshot();
+  await testInfo.attach('screenshot', { body: screenshot, contentType: 'image/png' });
+
+  await expect(page.getByRole('button', { name: 'Organize by Forms' })).toBeVisible();
+  await page.getByRole('button', { name: 'Organize by Forms' }).click();
+  await expect(page.getByRole('button', { name: 'Multiple person designated' })).toBeVisible();
+  await page.getByRole('button', { name: 'Multiple person designated' }).click();
+
+  
+});
+
+//Cleanup Remove Request
+
+test('Clean up NewRequest Form', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
+ await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+
+  //Find Request
+  await page.getByRole('link', {name: serviceRequest}).click();
+  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel Request' }).click();
+
+  //Verify you want to Cancel Request
+
+  await page.getByRole('dialog').getByText('Editor Close').click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
+  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+});
+
+//Cleanup Stapled Request
+
+test('Clean up Stapled Request Form', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
+ await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+
+  //Find Request
+  await page.getByRole('link', {name: stapledRequest}).click();
+  await expect(page.getByRole('button', { name: 'Cancel Request' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel Request' }).click();
+
+  //Verify you want to Cancel Request
+
+  await page.getByRole('dialog').getByText('Editor Close').click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).fill('Comment Delete');
+  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+});
+
+//Removed Stapled Forms
+test('Remove Stapled Forms', async ({ page }, testInfo) => {
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  //Click on Form Editor
+  await expect(page.getByRole('link', { name: 'Admin Panel' })).toBeVisible();
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await expect(page.getByRole('button', { name: ' Form Editor Create and' })).toBeVisible();
+  await page.getByRole('button', { name: ' Form Editor Create and' }).click();
+
+  //Find Multiple person designated Form
+  await expect(page.getByRole('link', { name: 'Multiple person designated', exact: true })).toBeVisible();
+  await page.getByRole('link', { name: 'Multiple person designated', exact: true }).click();
+
+  //Remove the stapled Form
+  await expect(page.getByRole('button', { name: 'Staple other form' })).toBeVisible();
+  await page.getByRole('button', { name: 'Staple other form' }).click();
+  await expect(page.getByText('Test IFTHEN staple [ Remove ]')).toBeVisible();
+  await page.getByRole('button', { name: 'remove Test IFTHEN staple' }).click();
+  await expect(page.getByText('Close')).toBeVisible();
+  await page.getByText('Close').click();
+
+  //Verify stapled Fprm is removed
+  await expect(page.locator('#form_index_display')).toMatchAriaSnapshot(`
+    - status
+    - button "Preview this Form"
+    - button "Add Internal-Use"
+    - button "Staple other form"
+    - list:
+      - listitem:
+        - button "Multiple person designated, main form"
+    `);
+
+  //Return Home
+  await page.getByRole('link', { name: 'Home' }).click();
+  
+
+});
+
+//Delete Customized Card
+
+test('delete Customized Sitemap Card', async ({ page }, testInfo) => {
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  await page.getByRole('link', { name: 'Admin Panel' }).click();
+  await page.getByRole('button', { name: ' Sitemap Editor Edit portal' }).click();
+
+  await expect(page.getByRole('button', { name: '+ Add Site' })).toBeVisible();
+  await page.getByRole('heading', { name: siteMapname }).getByRole('link').click();
+  await page.getByRole('button', { name: 'Delete Site' }).click();
+
+ });


### PR DESCRIPTION
## Summary
This is end to end testing for [LEAF-4823 ](https://github.com/department-of-veterans-affairs/LEAF/pull/2746)

## Testing
Test Scripts test the following:

1. Creating a New Site Map
2. Verifying the Site Map in the Inbox
3. Customization of the Column Display inside the Site Map
4. Verify that a certain form with customization display as expected
5. Verifying when a form is stapled the correct type is being displayed

![image](https://github.com/user-attachments/assets/a9e1b466-48ae-41a3-b7bb-5709afeecec6)
