### PR TITLE
Quick Fix for Copy Workflow Test Case

### DIFF
--- a/end2end/tests/adminPanelWorkflowEditor.spec.ts
+++ b/end2end/tests/adminPanelWorkflowEditor.spec.ts
@@ -158,6 +158,7 @@ test('Copy workflow', async ({ page }) => {
     await page.reload();
     const copyWorkflowButton = page.locator('#btn_duplicateWorkflow');
     await expect(copyWorkflowButton).toBeVisible();
+    await page.waitForLoadState('domcontentloaded')
     await copyWorkflowButton.click();
 
     // Wait for the "Duplicate Workflow" dialog to appear
@@ -168,6 +169,8 @@ test('Copy workflow', async ({ page }) => {
     // Confirm that the copied workflow appears in the list
     await saveButton.click();
     await expect(page.locator('a').filter({ hasText: copiedWorkflowTitle })).toBeVisible();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByText('Submit', { exact: true })).toBeVisible();
     await page.click("div.jtk-overlay");
     await page.locator("div.workflowStepInfo button.buttonNorm").last().click();
     await page.click("span#confirm_saveBtnText:first-child");


### PR DESCRIPTION
## Summary
\

## Testing
Added  two " await page.waitForLoadState('domcontentloaded') " and a visibility locator to allow the test case to run.