### PR TITLE
Cleanup: Add ENV Variable for HostURL

### DIFF
--- a/API-tests/main_test.go
+++ b/API-tests/main_test.go
@@ -14,10 +14,10 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-const HostURL = "https://host.docker.internal"
-const RootURL = "https://host.docker.internal/Test_Request_Portal/"
-const NationalOrgchartURL = "https://host.docker.internal/LEAF_NationalNexus/"
-const RootOrgchartURL = "https://host.docker.internal/Test_Nexus/"
+const HostURL = os.Getenv("APP_URL_NEXUS")
+const RootURL = HostURL + "Test_Request_Portal/"
+const NationalOrgchartURL = HostURL + "LEAF_NationalNexus/"
+const RootOrgchartURL = HostURL + "Test_Nexus/"
 
 var dbHost = os.Getenv("MYSQL_HOST")
 var dbUsername = os.Getenv("MYSQL_USER")

--- a/API-tests/main_test.go
+++ b/API-tests/main_test.go
@@ -14,10 +14,10 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-const HostURL = os.Getenv("APP_URL_NEXUS")
-const RootURL = HostURL + "Test_Request_Portal/"
-const NationalOrgchartURL = HostURL + "LEAF_NationalNexus/"
-const RootOrgchartURL = HostURL + "Test_Nexus/"
+var HostURL = "https://" + os.Getenv("APP_HTTP_HOST")
+var RootURL = HostURL + "/Test_Request_Portal/"
+var NationalOrgchartURL = HostURL + "/LEAF_NationalNexus/"
+var RootOrgchartURL = HostURL + "/Test_Nexus/"
 
 var dbHost = os.Getenv("MYSQL_HOST")
 var dbUsername = os.Getenv("MYSQL_USER")


### PR DESCRIPTION
## Summary

1. Added ENV Variable for HostURL for the API-tests/main_test.go as to provide a constant variable for all environments and reduce file editing per environment.