### PR TITLE
Agent: Cleanup Agent DB

### DIFF
--- a/API-tests/database/portal_agent_db.sql
+++ b/API-tests/database/portal_agent_db.sql
@@ -374,7 +374,6 @@ CREATE TABLE `indicators` (
   `timeAdded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `disabled` int unsigned NOT NULL DEFAULT '0',
   `is_sensitive` tinyint NOT NULL DEFAULT '0',
-  `trackChanges` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`indicatorID`),
   KEY `categoryID` (`categoryID`),
   KEY `parentID` (`parentID`),


### PR DESCRIPTION
## Summary

1. Remove the trackChanges indicator so the DB_Update can handle it without duplicate errors.