### PR TITLE
test 4680 increase client timeout, remove negative test

### DIFF
--- a/API-tests/events_test.go
+++ b/API-tests/events_test.go
@@ -235,26 +235,3 @@ func TestEvents_EditValidCustomEmailEvent(t *testing.T) {
 
 	confirmEmailTemplatesRecordValues(t, new_ev_valid.EventID, new_ev_valid.EventDescription)
 }
-
-/* This is to show off what will happen if you try and use a utf8 era character in latin1*/
-func TestEvents_Special_Character(t *testing.T) {
-	this_is_a_only_a_simley_face_test := WorkflowEvent{
-		EventID:          "this_is_a_only_a_simley_face_test",
-		EventDescription: "This is a simley face 😀 Text afterwards",
-		EventType:        "Email",
-	}
-	theMorphedText := "This is a simley face ? Text afterwards"
-	_, err := postEvent(RootURL+`api/workflow/events`, this_is_a_only_a_simley_face_test, map[string]string{})
-	if err != nil {
-		t.Error(err)
-	}
-
-	event, err := getEvent(RootURL + `api/workflow/event/_` + this_is_a_only_a_simley_face_test.EventID)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if event[0].EventDescription != theMorphedText {
-		t.Errorf(`Title %v Does not match %v.`, event[0].EventDescription, theMorphedText)
-	}
-}

--- a/API-tests/main_test.go
+++ b/API-tests/main_test.go
@@ -33,7 +33,7 @@ var tr = &http.Transport{
 var cookieJar, _ = cookiejar.New(nil)
 var client = &http.Client{
 	Transport: tr,
-	Timeout:   time.Second * 5,
+	Timeout:   time.Second * 10,
 	Jar:       cookieJar,
 }
 


### PR DESCRIPTION
## Summary
Increases the timeout for the client used in Go tests to 10 seconds.  API tester was sometimes failing if the updateDatabase script that processes DB update files took more than 5 seconds to run.

Removes a negative test associated with latin1 character set


## Testing
Test branch for LEAF-4680