### PR TITLE
LEAF-4892 initial commit

### DIFF
--- a/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
+++ b/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Locator } from '@playwright/test';
 
 //This test 
 
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: 'default' });
 
 // Global Variables
   let randNum = Math.random();
@@ -306,3 +306,221 @@ test('Verify Event Removed from Workflow Action', async ({ page }, testInfo) => 
   
   });
   
+ // test.describe.configure({ mode: 'default' });
+
+test.describe('LEAF 4892 ', () => {
+
+test('Create Email Action', async({page}) =>{
+
+ const eventName = 'LEAF_4892_Testing'; 
+ const eventDescription = 'End2end Testing for 4892';
+ const eventGroup = '202';
+ const eventTitle = 'Email - End2end Testing for 4892';
+    //Create an Event
+  await page.goto('https://host.docker.internal/Test_Request_Portal/admin/?a=workflow&workflowID=1');
+  
+  //Wait for Page to full Load
+  await page.waitForLoadState('load');
+
+  await expect(page.getByText('Requestor Step 1 Step 2')).toBeVisible();
+  await expect(page.getByText('Submit')).toBeVisible();
+
+  await page.getByText('Submit').click();
+
+  await page.waitForLoadState('load');
+  await page.getByRole('button', { name: 'Add Event' }).click();
+  await page.getByRole('dialog', { name: 'Add Event' }).locator('a').click();
+  await page.getByRole('option', { name: 'Email - Notify the requestor' }).click();
+  await page.getByRole('button', { name: 'Create Event' }).click();
+
+  await page.waitForLoadState('load');
+  await page.getByRole('textbox', { name: 'Event Name:' }).click();
+  await page.getByRole('textbox', { name: 'Event Name:' }).fill(eventName);
+  await page.getByRole('textbox', { name: 'Short Description: Notify' }).click();
+  await page.getByRole('textbox', { name: 'Short Description: Notify' }).fill(eventDescription);
+  await page.getByLabel('Notify Group:', { exact: true }).selectOption(eventGroup);
+  //await page.getByRole('button', { name: 'Save' }).selectOption(eventGroup);
+  await page.getByLabel('Notify Group:', { exact: true }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  //Verify it is present
+
+  await page.waitForLoadState('load');
+  await expect(page.getByText(eventTitle)).toBeVisible();
+  await page.getByRole('button', { name: 'Close Modal' }).click();
+
+  //Modify Email Template
+  await page.getByRole('button', { name: 'Edit Events' }).click();
+  await page.waitForLoadState('load');
+  await page.locator('#editor_CustomEvent_LEAF_4892_Testing').getByRole('button', { name: 'Edit' }).click();
+  const page1Promise = page.waitForEvent('popup');
+
+  await page.getByRole('link', { name: 'Email Template Editor' }).click();
+  const page1 = await page1Promise;
+
+  await page.waitForLoadState('load');
+  await page1.getByRole('button', { name: 'End2end Testing for' }).click();
+  await expect(page1.getByRole('heading', { name: 'End2end Testing for' })).toBeVisible();
+  await expect(page1.getByRole('textbox', { name: 'Email To:' })).toBeVisible();
+  await page1.getByRole('textbox', { name: 'Email To:' }).click();
+  await page1.getByRole('textbox', { name: 'Email To:' }).fill('{{$field.19}}\ntest4892@fake.com');
+  await page1.getByRole('textbox', { name: 'Email CC:' }).fill('test4892@fake.com');
+  
+  await page1.getByRole('button', { name: 'Save Changes' }).click();
+  await expect(page1.getByText('Please note that only')).toBeVisible();
+
+
+});
+
+test('Create New Request', async({page}) =>{
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  
+  const requestTitle = 'LEAF_4892_Test';
+  const formType = 'General Form';
+  const serviceType = 'AS - Service';
+  const serviceGroup = '2911 TEST Group';
+  const reviewerOne = 'Dare, Lyn Waters. Human Sales';
+  const singlelineText = 'Single line Text';
+  const reviewerUserName = "userName:VTRCFDJENINE";
+  const groupId = 'group#202';
+
+  //Wait for Page to full Load
+  await page.waitForLoadState('load');
+
+  await expect(page.getByText('New Request Start a new')).toBeVisible();
+  await page.getByText('New Request', { exact: true }).click();
+
+  await page.waitForLoadState('load');
+
+  //Create the Request
+  await expect(page.getByRole('heading', { name: 'Step 1 - General Information' })).toBeVisible();
+  await page.getByRole('cell', { name: 'Select an Option Service' }).locator('a').click();
+  await page.getByRole('option', { name: serviceType}).click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).click();
+  await page.getByRole('textbox', { name: 'Title of Request' }).fill(requestTitle);
+  await page.locator('label').filter({ hasText: formType }).locator('span').click();
+  await page.getByRole('button', { name: 'Click here to Proceed' }).click();
+
+  //1. Single line Text
+  await page.waitForLoadState('load');
+
+ 
+  await page.waitForLoadState('load');
+  await page.getByRole('textbox', { name: 'Numeric' }).click();
+  await page.getByRole('textbox', { name: 'Numeric' }).fill('1922'); 
+  
+  await expect(page.locator('#nextQuestion')).toBeVisible();
+  await page.locator('#nextQuestion').click();
+
+  await expect(page.getByText('2. Assigned Person')).toBeVisible();
+  
+  
+  //2. Assigned Person
+  await expect(page.getByText('Form completion progress: 0% Next Question')).toBeVisible();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Assigned Person', exact: true })).toBeVisible();
+  await page.getByRole('searchbox', { name: 'Search for user to add as Assigned Person', exact: true }).click();
+  await page.getByRole('searchbox', { name: 'Search for user to add as Assigned Person', exact: true }).fill('da');
+  await page.getByRole('cell', { name: reviewerOne}).click();
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as Assigned Person', exact: true })).toHaveValue(reviewerUserName);
+  await expect(page.getByText('3. Assigned Group')).toBeVisible();
+  await page.getByText('3. Assigned Group').click();
+  //await page.locator('#nextQuestion').click();
+   
+  await page.waitForLoadState('load');
+
+  //3. Assigned Group
+    
+  await expect(page.getByText('Form completion progress: 50% Next Question')).toBeVisible();
+
+  await page.getByRole('searchbox', { name: 'Search for user to add as' }).click();
+  await page.getByRole('searchbox', { name: 'Search for user to add as' }).fill('g');
+  await page.getByRole('cell', { name: serviceGroup }).click();
+  await expect(page.getByRole('searchbox', { name: 'Search for user to add as' })).toHaveValue(groupId);
+  await expect(page.locator('#nextQuestion')).toBeVisible();
+  await page.locator('#nextQuestion').click();
+
+  await page.waitForLoadState('load');
+
+  //Submit Request
+  await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
+  await page.getByRole('button', { name: 'Submit Request' }).click();
+
+});
+
+test('Verify Email', async({page}) =>{
+
+  await page.goto('http://host.docker.internal:5080/');
+
+  await page.waitForLoadState('load');
+
+  await page.locator('td:nth-child(2) > .cell').first().click();
+  await expect(page.getByLabel('Messages')).toContainText('To: test4892@fake.com, Loyd.Cartwright10@fake-email.com, Morton.Anderson@fake-email.com, Roman.Abbott@fake-email.com, Booker.Feeney@fake-email.com,');
+  await page.getByRole('tab', { name: 'Headers' }).click();
+
+});
+
+//Clean up
+
+test('Clean up Test Data', async({page}) =>{
+
+ await page.goto('https://host.docker.internal/Test_Request_Portal/');
+
+  const requestTitle = 'LEAF_4892_Test';
+  const dynRegexrequestTitle = new RegExp(`^\\d+\\s${requestTitle}`);
+  const commentText ='Cleaning Up';
+   
+
+  await page.waitForLoadState('load');
+  
+  await expect(page.getByText('Inbox Review and apply')).toBeVisible();
+  await page.getByRole('textbox', { name: 'Enter your search text' }).click();
+  await page.getByRole('textbox', { name: 'Enter your search text' }).fill(requestTitle);
+
+  await page.getByRole('cell', { name: dynRegexrequestTitle }).click();
+  await expect(page.getByText('Group A')).toBeVisible();
+  
+  let requestId = await page.textContent('#headerTab');
+  console.log('Text inside span:', requestId);
+  let str ;
+  str = requestId;
+  let parts = str.split("#", 2);
+  let firstPart = parts[0];
+  let secondPart = parts[1];
+  console.log(firstPart, secondPart);
+  requestId =secondPart;
+  const cancelledText = `Request #${requestId} has been cancelled!`;
+
+
+  await page.getByRole('button', { name: 'Cancel Request' }).click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).click();
+  await page.getByRole('textbox', { name: 'Enter Comment' }).fill(commentText);
+  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
+  await page.getByRole('button', { name: 'Yes' }).click();
+  await expect(page.locator('#bodyarea')).toContainText(cancelledText);
+
+  await page.getByRole('link', { name: 'Home' }).click();
+});
+
+test('Clean up Test Data Workflow', async({page}) =>{
+
+  await page.goto('https://host.docker.internal/Test_Request_Portal/admin/?a=workflow&workflowID=1');
+ 
+  const deleteBtn = '#editor_CustomEvent_LEAF_4892_Testing';
+
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('button', { name: 'Edit Events' })).toBeVisible();
+  await page.getByRole('button', { name: 'Edit Events' }).click();
+
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('heading', { name: 'List of Events' })).toBeVisible();
+
+  await expect(page.locator(deleteBtn).getByRole('button', { name: 'Delete' })).toBeVisible();
+  await page.locator(deleteBtn).getByRole('button', { name: 'Delete' }).click();
+
+  await expect(page.getByText('Confirmation required')).toBeVisible();
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+ 
+});
+});

--- a/end2end/tests/adminPanelWorkflowEditor.spec.ts
+++ b/end2end/tests/adminPanelWorkflowEditor.spec.ts
@@ -648,4 +648,3 @@ test('Workflow editor UX improvements - 4716', async ({ page }) => {
     
 });
 
-


### PR DESCRIPTION
## Summary
Adds Orgchart Group as an allowed format in the Email Template Editor To and Cc fields
Adds missing smarty email variable assignment to next approver template.

When used within To or Cc fields, the orgchart_group will be used to get a list of group member emails

See PR  [##LEAF-4892](https://github.com/department-of-veterans-affairs/LEAF/pull/2778) for more details

## Testing
Test Scripts Created (test steps in [SharePoint](https://sierra7inc.sharepoint.com/:f:/r/sites/LEAF2.0/Shared%20Documents/LEAF%20Testing/Test%20Cases/Workflow%20Editor/Email%20Event?csf=1&web=1&e=hM69x4) )

- Create Email Action (create the email action to add the orgchart group)
- Create a New Request ( create a new request based on the workflow with the email action)
- Verify Email (verify email is sent to the orgchart_group )

Screenshot before:
<img width="1323" height="533" alt="image" src="https://github.com/user-attachments/assets/688b71d9-5106-406d-bc85-fac7ca3fe278" />


Screenshot after:
<img width="1326" height="493" alt="image" src="https://github.com/user-attachments/assets/b101c36e-19ea-4e9b-8aa6-f178a95e40aa" />
