### PR TITLE
LEAF 4970 - end2end test for LEAF 4969 Remove trailing space in "resolved by" responses

### DIFF
--- a/end2end/tests/lifecycleReportBuilder.spec.ts
+++ b/end2end/tests/lifecycleReportBuilder.spec.ts
@@ -380,3 +380,27 @@ test('New Row Added in Correct Place After Sorting', async ({ page }) => {
   await page.getByRole('button', { name: 'Yes' }).click();
   
 });
+/**
+ * Test for LEAF 4969
+ */
+test('No Trailing Space After Resolver Name', async ({ page }) => {
+
+  // Go to Report Builder
+  await page.goto('https://host.docker.internal/Test_Request_Portal/');
+  await page.getByText('Report Builder').click();
+
+  // Set filter to Current Status IS Resolved
+  await page.getByRole('cell', { name: 'IS NOT' }).locator('a').click();
+  await page.getByRole('option', { name: 'IS', exact: true }).click();
+  await page.getByRole('button', { name: 'Next Step' }).click();
+
+  // Add Resolved By as a column in the report
+  await page.getByTitle('Resolved By').locator('span').click();
+  await page.getByRole('button', { name: 'Generate Report' }).click();
+  
+  const resolvedBy = await page.locator('[id$="_9_resolvedBy"]');
+
+  // Verify that the Resolved By name does not end with a space
+  await expect(resolvedBy).toHaveText(/Tester Tester$/);
+  await expect(resolvedBy).not.toHaveText(/Tester Tester\s+$/);
+});


### PR DESCRIPTION
This is an end2end test for validating the changes in the following PR:
https://github.com/department-of-veterans-affairs/LEAF/pull/2777

The test does the following:
1. Go to Report Builder
2. Set filter to Current Status IS Resolved
3. Add Resolved By as a column
4. Expect the Resolved By name to be Tester Tester with no ' ' at the end

The original branch fix-formatting was behind on the Master code and caused the API Tester to fail. 
Merging this branch with the current code in master and running the end2end tests would result in various failures that are already known. 
For Example:
<img width="1047" height="251" alt="Failure" src="https://github.com/user-attachments/assets/8bcec16b-de08-4f83-a782-8a1bd774cefa" />
In the end2end testing you can see that the new test "No Trailing Space After Resolver Name" has passed
<img width="1071" height="724" alt="New Test" src="https://github.com/user-attachments/assets/71fd6ef2-8ffc-4785-af45-995d47c8f550" />
