### PR TITLE
add test for clickable single-line links

### DIFF
--- a/API-tests/database/portal_test_db.sql
+++ b/API-tests/database/portal_test_db.sql
@@ -1202,7 +1202,7 @@ INSERT INTO `data` (`recordID`, `indicatorID`, `series`, `data`, `metadata`, `ti
 (14,	5,	1,	'41045',	NULL,	1694021465,	'tester'),
 (14,	8,	1,	'86',	'{\"email\": \"Cristopher.Cummings@fake-email.com\", \"lastName\": \"Cummings\", \"userName\": \"vtradqmyra\", \"firstName\": \"Cristopher\", \"middleName\": \"Frami\"}',	1695331172,	'tester'),
 (14,	10,	1,	'199',	'{\"email\": \"Carmine.Bins@fake-email.com\", \"lastName\": \"Bins\", \"userName\": \"vtrsfyflossie\", \"firstName\": \"Carmine\", \"middleName\": \"Casper\"}',	1695339059,	'tester'),
-(15,	3,	1,	'36483',	NULL,	1694021465,	'tester'),
+(15,	3,	1,	'https://va.gov',	NULL,	1694021465,	'tester'),
 (15,	4,	1,	'https://va.gov https://va.gov/about https://va.gov/?param=1234&amp;test https://va.gov &lt;a href=&quot;https://va.gov&quot;&gt;va.gov&lt;/a&gt;',	NULL,	1694021465,	'tester'),
 (15,	5,	1,	'51717',	NULL,	1694021465,	'tester'),
 (15,	8,	1,	'263',	'{\"email\": \"Jc.Conn@fake-email.com\", \"lastName\": \"Conn\", \"userName\": \"vtrhkwpenny\", \"firstName\": \"Jc\", \"middleName\": \"Schiller\"}',	1695331172,	'tester'),

--- a/end2end/tests/printview.spec.ts
+++ b/end2end/tests/printview.spec.ts
@@ -18,7 +18,10 @@ test('workflow form fields load after subsequent getWorkflow() executions', asyn
 
 test('links in user content are visible', async ({ page }) => {
   await page.goto('https://host.docker.internal/Test_Request_Portal/index.php?a=printview&recordID=15');
-  await expect(page.getByRole('link', { name: 'https://va.gov' }).first()).toBeVisible();
-  await expect(page.getByRole('link', { name: 'https://va.gov' }).nth(3)).toBeVisible();
+
+  // there should be 5 links (nth is 0-index based)
+  await expect(page.getByRole('link', { name: 'https://va.gov' }).nth(4)).toBeVisible();
+
+  // check explicit tags
   await expect(page.locator('#data_4_1')).toContainText('<a href="https://va.gov">va.gov</a>');
 });


### PR DESCRIPTION
⚠️ This requires https://github.com/department-of-veterans-affairs/LEAF/pull/2792 to work

This expands the test case for clickable URLs, and removes a redundant expect().