### PR TITLE
Inbox Flaky & Failed Test Update

### DIFF
--- a/end2end/playwright.config.ts
+++ b/end2end/playwright.config.ts
@@ -13,7 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: 2,

--- a/end2end/tests/adminPanelFormEditor.spec.ts
+++ b/end2end/tests/adminPanelFormEditor.spec.ts
@@ -135,18 +135,30 @@ test.describe('LEAF-4891 Create New Request, Send Mass Email, then Verify Email'
      await page.goto('http://host.docker.internal:5080/');
     
    //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('load');
 
-  await page.getByText('leaf.noreply@fake-email.com').first().click();
-  
-   await expect(page.getByRole('tab', { name: 'View' })).toBeVisible();
-  await page.getByRole('tab', { name: 'View' }).click();
+  await expect(page.locator('#maintabs div').filter({ hasText: 'Messages Sessions' }).nth(2)).toBeVisible();
 
-  await expect(page.getByLabel('Messages')).toContainText('To: tester.tester@fake-email.com, Donte.Glover@fake-email.com,');
-  await expect(page.getByLabel('Messages')).toContainText('To: Rhona.Goodwin@fake-email.com,');
-  await expect(page.getByLabel('Messages')).toContainText('Subject: Reminder for General Form');
+   await page.getByText('leaf.noreply@fake-email.com').first().click();
 
- 
+    await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`
+    - paragraph: "From: leaf.noreply@va.gov"
+    - paragraph:
+      - text: "To:"
+      - strong: tester.tester@fake-email.com
+      - text: ","
+      - strong: Donte.Glover@fake-email.com
+      - text: ","
+    - paragraph:
+      - text: "To:"
+      - strong: Rhona.Goodwin@fake-email.com
+      - text: ","
+    - paragraph: "/Subject: Reminder for General Form \\\\(#\\\\d+\\\\)/"
+    `);
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+
   });
 
   test('Cancel Request', async ({ page }, testInfo) => {

--- a/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
+++ b/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Locator } from '@playwright/test';
 
 //This test 
 
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: 'default' });
 
 // Global Variables
   let randNum = Math.random();

--- a/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
+++ b/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
@@ -183,6 +183,7 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
 
    await expect(page.locator('#maintabs div').filter({ hasText: 'Messages Sessions' }).nth(2)).toBeVisible();
 
+  await page.getByText('The request for General Form (#113) has been canceled.').TO;
   await page.getByText('The request for General Form (#113) has been canceled.').click();
 
     await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`

--- a/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
+++ b/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
@@ -199,7 +199,7 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
     await page.waitForLoadState('load');
     
     
-  await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#114) has been canceled.');
+// await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#114) has been canceled.');
 
 
    await page.getByText('leaf.noreply@fake-email.com').first().click();

--- a/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
+++ b/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
@@ -183,7 +183,6 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
 
    await expect(page.locator('#maintabs div').filter({ hasText: 'Messages Sessions' }).nth(2)).toBeVisible();
 
-  await page.getByText('The request for General Form (#113) has been canceled.').TO;
   await page.getByText('The request for General Form (#113) has been canceled.').click();
 
     await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`
@@ -200,7 +199,7 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
     await page.waitForLoadState('load');
     
     
-// await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#114) has been canceled.');
+//await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#114) has been canceled.');
 
 
    await page.getByText('leaf.noreply@fake-email.com').first().click();
@@ -216,7 +215,6 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
       
    await page.getByRole('button', { name: 'Delete' }).click();
   
- 
   
   //Reset  the Request
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
@@ -241,6 +239,7 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Take Action' }).nth(1).click();
   await page.getByRole('button', { name: 'Yes' }).click();
 
+ 
   await page.waitForLoadState('load');
   await expect(page.getByRole('heading', { name: 'Mass Action' })).toBeVisible();
   await expect(page.locator('#errorMessage')).toContainText('No Results');
@@ -334,7 +333,7 @@ await page.locator('#selectAllRequests').check();
   
 });
 
-//End of TC-003
+//End of TC-004
 
 }); //End of describe
 

--- a/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
+++ b/end2end/tests/emailRequestCancelwithMassActionCancel.spec.ts
@@ -2,7 +2,10 @@ import { test, expect } from '@playwright/test';
 
 test.describe.configure({ mode: 'default' });
 
-test.describe('Cancel Request, View Email and Clean up', () => {
+test.describe('LEAF - 4872, Canel Submitted Request, Cancel unSubmitted Request, MassAction Cancel', () => {
+
+
+
 test('Cancel Submitted Request', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/index.php?a=printview&recordID=112');
@@ -25,17 +28,28 @@ test('Cancel Submitted Request', async ({ page }, testInfo) => {
   await page.goto('http://host.docker.internal:5080/');
 
   //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
-
+  await page.waitForLoadState('load');
   await page.getByText('leaf.noreply@fake-email.com').first().click();
 
- await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#112) has been canceled.');
+ // await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#112) has been canceled.');
 
-  //Cleanup
+ await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`
+    - paragraph: "From: leaf.noreply@va.gov"
+    - paragraph:
+      - text: "To:"
+      - strong: tester.tester@fake-email.com
+      - text: ","
+    - paragraph: "Subject: The request for General Form (#112) has been canceled."
+    `);
+
+  //Cleanup the inbox
+     await page.getByRole('button', { name: 'Delete' }).click();
+
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
   
   //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('load');
+  
   
   await expect(page.getByLabel('Choose Action')).toBeVisible();
   await page.getByLabel('Choose Action').selectOption('restore');
@@ -54,10 +68,8 @@ test('Cancel Submitted Request', async ({ page }, testInfo) => {
 
 
 });
-});
 //End of TC-001
 
-test.describe('Cancel Unsubmitted Request and View Email', () => {
 test('Cancel unSubmitted Request', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/');
@@ -117,64 +129,95 @@ test('Cancel unSubmitted Request', async ({ page }, testInfo) => {
   //Wait for page to load
   await page.waitForLoadState('domcontentloaded');
 
-  await page.getByText('leaf.noreply@fake-email.com').first().click();
-
-  await expect(page.getByLabel('Messages')).not.toContainText(subjectTxt);
+  await expect(page.getByRole('cell', { name: subjectTxt}).locator('div')).not.toBeVisible();
 
 });
-});
+
 //End of TC-002
 
-
-test.describe('Cancel Mass Action Request, View Email and Clean up', () => {
 test('Cancel MassAction Request', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
   
-  //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+  let massCancel = 'LEAF-4872 Mass Cancelation';
+ 
+  let txtBoxMsg = 'Cancel #113 & #114';
+  let ckbox113 = '113 General Form LEAF-4872';
+  let ckbox114 = '114 General Form LEAF-4872';
+  
+
+  
+   //Wait for page to load
+  await page.waitForLoadState('load');
 
   await expect(page.getByLabel('Choose Action')).toBeVisible();
   
-  //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
-
   await page.getByLabel('Choose Action').selectOption('cancel');
-
-    //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('button', { name: 'Take Action' }).first()).toBeVisible();
-   
+  
   await expect(page.getByRole('textbox', { name: 'Comment * required' })).toBeVisible();
-  await page.getByRole('textbox', { name: 'Comment * required' }).fill('Cancel #113 & #114');
+  await page.getByRole('textbox', { name: 'Comment * required' }).fill(txtBoxMsg);
+  
+  await page.getByRole('textbox', { name: 'Enter your search text' }).fill('LEAF-4872 Mass Cancelation');
+  await expect(page.getByRole('textbox', { name: 'Enter your search text' })).toHaveValue(massCancel);
 
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('button', { name: 'Take Action' }).first()).toBeVisible();
+     
+  await page.getByRole('row', { name: ckbox113 }).getByRole('checkbox').check();
+  await page.getByRole('row', { name: ckbox114 }).getByRole('checkbox').check();
+  await page.getByRole('button', { name: 'Take Action' }).nth(1).click();
 
-  await expect(page.getByRole('textbox', { name: 'Enter your search text' })).toBeVisible();
-
-  await page.getByRole('textbox', { name: 'Enter your search text' }).click();
-  await page.getByRole('textbox', { name: 'Enter your search text' }).fill('LEAF-4872');
-
-
-  await page.locator('input#selectAllRequests').click();
-
-  await page.getByRole('button', { name: 'Take Action' }).first().click();
   await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
   await page.getByRole('button', { name: 'Yes' }).click();
 
 
    //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
-  await page.locator("div.progress").waitFor({ state: 'visible' });
-  
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('heading', { name: 'Mass Action' })).toBeVisible();
+
+  //Check the inbox
   await page.goto('http://host.docker.internal:5080/');
-    
+   
    //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+   await page.waitForLoadState('load');
 
-  await page.getByText('leaf.noreply@fake-email.com').first().click();
+   await expect(page.locator('#maintabs div').filter({ hasText: 'Messages Sessions' }).nth(2)).toBeVisible();
 
-  await expect(page.locator('iframe').contentFrame().getByText('Reason for cancelling: Cancel #113 & #114')).toBeVisible();
+  await page.getByText('The request for General Form (#113) has been canceled.').click();
 
+    await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`
+    - paragraph: "From: leaf.noreply@va.gov"
+    - paragraph:
+      - text: "To:"
+      - strong: tester.tester@fake-email.com
+      - text: ","
+    - paragraph: "Subject: The request for General Form (#113) has been canceled."
+    `);
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+    await page.waitForLoadState('load');
+    
+    
+  await expect(page.getByLabel('Messages')).toContainText('The request for General Form (#114) has been canceled.');
+
+
+   await page.getByText('leaf.noreply@fake-email.com').first().click();
+    //Check for #114
+     await expect(page.getByLabel('Messages')).toMatchAriaSnapshot(`
+    - paragraph: "From: leaf.noreply@va.gov"
+    - paragraph:
+      - text: "To:"
+      - strong: tester.tester@fake-email.com
+      - text: ","
+    - paragraph: "Subject: The request for General Form (#114) has been canceled."
+    `);
+      
+   await page.getByRole('button', { name: 'Delete' }).click();
+  
+ 
+  
+  //Reset  the Request
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
   
  //Wait for page to load
@@ -190,29 +233,34 @@ test('Cancel MassAction Request', async ({ page }, testInfo) => {
   await expect(page.getByRole('button', { name: 'Take Action' }).first()).toBeVisible();
 
    await page.getByRole('textbox', { name: 'Enter your search text' }).click();
-  await page.getByRole('textbox', { name: 'Enter your search text' }).fill('Leaf-4872');
+  await page.getByRole('textbox', { name: 'Enter your search text' }).fill(massCancel);
 
   await page.locator('input#selectAllRequests').click();
 
   await page.getByRole('button', { name: 'Take Action' }).nth(1).click();
   await page.getByRole('button', { name: 'Yes' }).click();
 
-  await page.waitForLoadState('domcontentloaded');
-  await page.locator("div.progress").waitFor({ state: 'visible' });
-
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('heading', { name: 'Mass Action' })).toBeVisible();
+  await expect(page.locator('#errorMessage')).toContainText('No Results');
 
 });
+//End of TC-003
+
 test('Suppress Cancel MassAction Request', async ({ page }, testInfo) => {
 
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
   
+  let supressMassCancel = `Leaf-4872 Supress Mass Cancelation`;
+  let txtBoxMsg2 = 'Cancel #115';
+  let subjectSupress = 'The request for General Form (#115) has been canceled.'
+  
+
+
   //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('load');
 
   await expect(page.getByLabel('Choose Action')).toBeVisible();
-  
-  //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
 
   await page.getByLabel('Choose Action').selectOption('cancel');
 
@@ -221,14 +269,18 @@ test('Suppress Cancel MassAction Request', async ({ page }, testInfo) => {
   await expect(page.getByRole('button', { name: 'Take Action' }).first()).toBeVisible();
    
   await expect(page.getByRole('textbox', { name: 'Comment * required' })).toBeVisible();
-  await page.getByRole('textbox', { name: 'Comment * required' }).fill('Cancel #115');
+  await page.getByRole('textbox', { name: 'Comment * required' }).fill(txtBoxMsg2);
+
 
   await page.getByRole('textbox', { name: 'Enter your search text' }).click();
-  await page.getByRole('textbox', { name: 'Enter your search text' }).fill('Leaf-4872');
-  await expect(page.getByRole('textbox', { name: 'Enter your search text' })).toHaveValue('Leaf-4872');
+  await page.getByRole('textbox', { name: 'Enter your search text' }).fill(supressMassCancel);
+  await expect(page.getByRole('textbox', { name: 'Enter your search text' })).toHaveValue(supressMassCancel);
 
+  await expect(page.getByRole('checkbox', { name: 'Suppress Email Notification' })).toBeVisible();
+  await page.getByRole('checkbox', { name: 'Suppress Email Notification' }).check();
+  //const ckboxMsg115 = new RegExp (`/#LeafFormGrid\\d+_115_checkbox/`);
 
-  await page.locator("input.massActionRequest").nth(0).click();
+await page.locator('#selectAllRequests').check();
 
   await page.getByRole('button', { name: 'Take Action' }).first().click();
 
@@ -239,15 +291,21 @@ test('Suppress Cancel MassAction Request', async ({ page }, testInfo) => {
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByText('1 successes and 0 failures of 1 total.')).toBeVisible();
   
+
+  //Check Inbox
   await page.goto('http://host.docker.internal:5080/');
     
-   //Wait for page to load
+
+  //Wait for page to load
   await page.waitForLoadState('domcontentloaded');
-  await page.getByText('leaf.noreply@fake-email.com').first().click();
+
+  await expect(page.getByRole('cell', { name: subjectSupress}).locator('div')).not.toBeVisible();
+
+  //Reset Request
   await page.goto('https://host.docker.internal/Test_Request_Portal/report.php?a=LEAF_mass_action');
   
- //Wait for page to load
-  await page.waitForLoadState('domcontentloaded');
+  //Wait for page to load
+  await page.waitForLoadState('load');
 
   await expect(page.getByLabel('Choose Action')).toBeVisible();
 
@@ -255,20 +313,27 @@ test('Suppress Cancel MassAction Request', async ({ page }, testInfo) => {
   await page.getByLabel('Choose Action').selectOption('restore');
 
   
-    //Wait for page to load
+  //Wait for page to load
   await page.waitForLoadState('domcontentloaded');
   await expect(page.getByRole('button', { name: 'Take Action' }).first()).toBeVisible();
 
-   await page.getByRole('textbox', { name: 'Enter your search text' }).click();
-  await page.getByRole('textbox', { name: 'Enter your search text' }).fill('Leaf-4872');
-  await page.locator("input.massActionRequest").nth(0).click();
+  await page.getByRole('textbox', { name: 'Enter your search text' }).fill(supressMassCancel);
+
+  await page.locator('#selectAllRequests').check();
+  
   await page.getByRole('button', { name: 'Take Action' }).nth(1).click();
+  await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
   await page.getByRole('button', { name: 'Yes' }).click();
 
   
-  await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByText('1 successes and 0 failures of 1 total.')).toBeVisible();
+  await page.waitForLoadState('load');
+  await expect(page.getByRole('heading', { name: 'Mass Action' })).toBeVisible();
+
+
   
 });
-});
+
+//End of TC-003
+
+}); //End of describe
 

--- a/end2end/tests/inboxCustomization.spec.ts
+++ b/end2end/tests/inboxCustomization.spec.ts
@@ -297,10 +297,7 @@ await page.waitForLoadState();
 
 });
 
- });
- //End of Creation and Customization
-
-test.describe('Creating and Validating Form Displays', () => {
+//End of Creation and Customization
 
 //Create a New MUltipleperson request
 test('Create a new Multiple Person Form', async ({ page }, testInfo) => {
@@ -700,11 +697,7 @@ test('View Stapled Request', async ({ page }, testInfo) => {
  
 });
 
-});
 //End of Form Verification
-
-
-test.describe('Clean up all test data', () =>{ 
 
 //Cleanup Remove Request
 
@@ -834,7 +827,6 @@ test('Remove Stapled Forms', async ({ page }, testInfo) => {
   await page.getByText('Close').click();
   
 });
-
 
 
 });


### PR DESCRIPTION


## Testing
Reduced the inbox test failing in two scenarios.  Before running end2end test clear out your inbox after you run the API

