### PR TITLE
LEAF-5030 - Clear email inbox

### DIFF
--- a/API-tests/zzinboxclear_test.go
+++ b/API-tests/zzinboxclear_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+const (
+	smtp4devBaseURL = "http://host.docker.internal:5080" // Default smtp4dev address.  Change if yours is different.
+)
+
+const defaultMailbox = "default" // Or whatever the correct identifier is
+
+// ClearInbox clears all emails from the smtp4dev inbox.
+func ClearInbox() error {
+	endpoint := "/api/messages/*"
+	urlStr := smtp4devBaseURL + endpoint
+
+	req, err := http.NewRequest("DELETE", urlStr, nil) // Use DELETE method
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK { // Or potentially 204 No Content
+		return fmt.Errorf("error deleting messages: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func GetMessageCount() (int, error) {
+	endpoint := "/api/messages"
+	urlStr := smtp4devBaseURL + endpoint
+
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return 0, fmt.Errorf("error creating request: %w", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Parse the JSON response
+	var data map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return 0, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	// Access the "rowCount" value
+	rowCount, ok := data["rowCount"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("missing or invalid 'rowCount' field")
+	}
+
+	return int(rowCount), nil
+}
+
+func TestClearInbox(t *testing.T) {
+	// 1. Get initial message count
+	_, err := GetMessageCount()
+	if err != nil {
+		t.Fatalf("Error getting initial message count: %v", err)
+	}
+
+	// 2. Clear the inbox
+	err = ClearInbox()
+	if err != nil {
+		t.Fatalf("Error clearing inbox: %v", err)
+	}
+
+	// 3. Get final message count
+	finalCount, err := GetMessageCount()
+	if err != nil {
+		t.Fatalf("Error getting final message count: %v", err)
+	}
+
+	// 4. Assert that the inbox is empty
+	if finalCount != 0 {
+		t.Errorf("Inbox not cleared. Final count is %d, expected 0", finalCount)
+	}
+
+}

--- a/API-tests/zzinboxclear_test.go
+++ b/API-tests/zzinboxclear_test.go
@@ -8,10 +8,8 @@ import (
 )
 
 const (
-	smtp4devBaseURL = "http://host.docker.internal:5080" // Default smtp4dev address.  Change if yours is different.
+	smtp4devBaseURL = "http://host.docker.internal:5080"
 )
-
-const defaultMailbox = "default" // Or whatever the correct identifier is
 
 // ClearInbox clears all emails from the smtp4dev inbox.
 func ClearInbox() error {


### PR DESCRIPTION
## Summary
This is a test that was written to clear the inbox after the api test is done and before the end to end is started to allow for the inbox to be clean for testing purposes. Previously you would have to manually clear the inbox and the test had to run in a very specific order.

## Impact
Allow for automatic clearing of inbox before the run of end to end. This is run after the api in case an api test generates any emails  it will be cleared out after the end of the api tests.

## Testing
How can we validate that the change is successful? If an automated test is provided, a link to the test can be provided instead of listing the validation steps.