### PR TITLE
Tests/further module updates 092625

### DIFF
--- a/end2end/leaf_test_utils/leaf_util_methods.ts
+++ b/end2end/leaf_test_utils/leaf_util_methods.ts
@@ -202,6 +202,30 @@ export const deleteTestRequestByRequestID = async (page:Page, requestID:string) 
   await expect(page.locator('#bodyarea')).toContainText('has been cancelled!');
 }
 
+/**
+ * Confirm an email with the given subject is present once and confirm recipients
+ * @param page Page instance from test
+ * @param emailSubjectText the text in the email's subject field, used to find the email
+ * @param expectedEmailRecipients array of email addresses that should be found as recipients
+ */
+export const confirmEmailRecipients = async (
+  page:Page,
+  emailSubjectText:string,
+  expectedEmailRecipients:Array<string>
+) => {
+  const row = page.locator(`tr:has-text("${emailSubjectText}")`);
+  await expect(
+    row, `one email with subject ${emailSubjectText} to be found`
+  ).toHaveCount(1);
+
+  const recipientEls = row.locator('.el-table_1_column_3 strong');
+  for (let i = 0; i < expectedEmailRecipients.length; i++) {
+    await expect(
+      recipientEls.filter({ hasText: expectedEmailRecipients[i] }),
+      `email recipient ${expectedEmailRecipients[i]} to be present once`
+    ).toHaveCount(1);
+  }
+}
 
 /**
  * Deletes a Workflow Event and asserts that it is not present in the Event List after deletion

--- a/end2end/tests/adminPanelFormEditor.spec.ts
+++ b/end2end/tests/adminPanelFormEditor.spec.ts
@@ -20,7 +20,7 @@ test.describe('Update heading of a General Form then reset back to original head
   const newText = `Single line text ${testId}`;
   let formEditorFieldsFormID = '';
 
-  test.only('edit a section heading', async ({ page }) => {
+  test('edit a section heading', async ({ page }) => {
     formEditorFieldsFormID = await createTestForm(page, `form_name_${testId}`, `form_descr_${testId}`);
     const sectionID = await addFormQuestion(page, 'Add Section', singleLineName, '');
     const headerEditSelector = `edit indicator ${sectionID}`;
@@ -47,7 +47,7 @@ test.describe('Update heading of a General Form then reset back to original head
 
 test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
   let requestID_emailing = '';
-  test.only('Create a New Request', async ({ page }) => {
+  test('Create a New Request', async ({ page }) => {
     const groupText = `Group A`;
     const assignedPersonOne = `Tester, Tester Product Liaison`;
     const assignedPersonIndId = '8';
@@ -69,7 +69,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
     await page.getByRole('cell', { name: assignedPersonOne }).click();
     await expect(page.locator(`#empSel_${assignedPersonIndId} img[id$="_iconBusy"]`)).not.toBeVisible();
     await expect(page.locator('#nextQuestion2')).toBeVisible();
-    //await page.waitForLoadState('networkidle'); //uncomment here and in 3. if this test is still flaky
+    await page.waitForLoadState('networkidle'); //helps ensure required orgchart field validation is complete
     await page.locator('#nextQuestion2').click();
 
     //3. Assigned Group - not an approver for step one, but required to proceed
@@ -79,7 +79,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
     await page.getByRole('cell', { name: groupText }).click();
     await expect(page.locator(`#grpSel_${assignedGroupIndId} img[id$="_iconBusy"]`)).not.toBeVisible();
     await expect(page.locator('#nextQuestion2')).toBeVisible();
-    //await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('networkidle');
     await page.locator('#nextQuestion2').click();
 
     await expect(page.getByRole('button', { name: 'Submit Request' })).toBeVisible();
@@ -97,7 +97,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
     });
   });
 
-  test.only('Mass Action Email Reminder', async ({ page }) => {
+  test('Mass Action Email Reminder', async ({ page }) => {
     await page.goto(LEAF_URLS.MASS_ACTION);
     await expect(page.getByText('Choose Action -Select- Cancel')).toBeVisible();
 
@@ -131,7 +131,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
     ).toBeVisible();
   });
 
-  test.only('email reminder is only sent to remaining dependency', { tag: ['@LEAF-4891'] }, async ({ page }) => {
+  test('email reminder is only sent to remaining dependency', { tag: ['@LEAF-4891'] }, async ({ page }) => {
     await page.goto(LEAF_URLS.EMAIL_SERVER);
     //approver 1 should be a recipient, but group A requirement has been met, so its member should not be
     const expectedSubject = `Reminder for General Form (#${requestID_emailing})`;
@@ -162,7 +162,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
 });
 
 
-test.only('warning message is displayed if both hidden and shown display states are on the same question', async ({ page }) => {
+test('warning message is displayed if both hidden and shown display states are on the same question', async ({ page }) => {
   await page.goto(LEAF_URLS.FORM_EDITOR);
 
   const formName = `Test LEAF-4888-${testId}`;
@@ -236,7 +236,7 @@ test.only('warning message is displayed if both hidden and shown display states 
 });
 
 
-test.only('Verify Alert Dialog does not Appear', async ({ page }) => {
+test('Verify Alert Dialog does not Appear', async ({ page }) => {
   const formName =`LEAF-5005_${testId}`;
   const formDescription =`FormDescription_${testId}`;
   const LEAF_5005_formId = await createTestForm(page, formName, formDescription);

--- a/end2end/tests/adminPanelFormEditor.spec.ts
+++ b/end2end/tests/adminPanelFormEditor.spec.ts
@@ -14,15 +14,15 @@ import {
 test.describe.configure({ mode: 'default' });
 
 const testId = getRandomId();
-const singleLineName = `Single line text`;
 
-test.describe('Update heading of a General Form then reset back to original heading', () => {
-  const newText = `Single line text ${testId}`;
+test.describe('Update heading of a form then reset back to original heading', () => {
+  const originalText = 'Section 1'
+  const newText = 'Edited Section 1';
   let formEditorFieldsFormID = '';
 
   test('edit a section heading', async ({ page }) => {
     formEditorFieldsFormID = await createTestForm(page, `form_name_${testId}`, `form_descr_${testId}`);
-    const sectionID = await addFormQuestion(page, 'Add Section', singleLineName, '');
+    const sectionID = await addFormQuestion(page, 'Add Section', originalText, '');
     const headerEditSelector = `edit indicator ${sectionID}`;
     const headerLabelSelector = `#format_label_${sectionID}`;
     await expect(page.getByTitle(headerEditSelector)).toBeVisible();
@@ -35,9 +35,9 @@ test.describe('Update heading of a General Form then reset back to original head
 
     await page.getByTitle(headerEditSelector).click();
     await expect(page.getByLabel('Section Heading')).toBeVisible();
-    await page.getByLabel('Section Heading').fill(singleLineName);
+    await page.getByLabel('Section Heading').fill(originalText);
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.locator(headerLabelSelector)).toContainText(singleLineName);
+    await expect(page.locator(headerLabelSelector)).toContainText(originalText);
 
     //cleanup
     await deleteTestFormByFormID(page, formEditorFieldsFormID);
@@ -49,6 +49,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
   let requestID_emailing = '';
   test('Create a New Request', async ({ page }) => {
     const groupText = `Group A`;
+    const singleLineName = `Single line text`;
     const assignedPersonOne = `Tester, Tester Product Liaison`;
     const assignedPersonIndId = '8';
     const assignedGroupIndId = '9';
@@ -69,7 +70,7 @@ test.describe('Create New Request, Send Mass Email, then Verify Email',  () => {
     await page.getByRole('cell', { name: assignedPersonOne }).click();
     await expect(page.locator(`#empSel_${assignedPersonIndId} img[id$="_iconBusy"]`)).not.toBeVisible();
     await expect(page.locator('#nextQuestion2')).toBeVisible();
-    await page.waitForLoadState('networkidle'); //helps ensure required orgchart field validation is complete
+    await page.waitForLoadState('networkidle'); //helps ensure required validation for an orgchart field is complete
     await page.locator('#nextQuestion2').click();
 
     //3. Assigned Group - not an approver for step one, but required to proceed

--- a/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
+++ b/end2end/tests/adminPanelWorkflowEditor-eventsEditor.spec.ts
@@ -1,35 +1,9 @@
 import { test, expect, Page } from '@playwright/test';
-import { awaitPromise, loadWorkflow, deleteWorkflowEvent } from '../leaf_test_utils/leaf_util_methods.ts';
+import {
+  awaitPromise, loadWorkflow, deleteWorkflowEvent, confirmEmailRecipients
+} from '../leaf_test_utils/leaf_util_methods.ts';
 
 test.describe.configure({ mode: 'default' });
-
-
-/**
- * @param page Page instance from test
- * @param emailSubjectText the text in the email's subject field, used to find the email
- * @param expectedEmailRecipients array of email addresses that should be found as recipients
- */
-const confirmEmailRecipients = async (
-  page:Page,
-  emailSubjectText:string,
-  expectedEmailRecipients:Array<string>
-) => {
-  const row = page.locator(`tr:has-text("${emailSubjectText}")`);
-  await expect(
-    row, `one email with subject ${emailSubjectText} to be found`
-  ).toHaveCount(1);
-
-  const recipientEls = row.locator('.el-table_1_column_3 strong');
-  for (let i = 0; i < expectedEmailRecipients.length; i++) {
-    await expect(
-      recipientEls.filter({ hasText: expectedEmailRecipients[i] }),
-      `email recipient ${expectedEmailRecipients[i]} to be present once`
-    ).toHaveCount(1);
-  }
-}
-
-
-
 
 /**
  * Use the printview admin menu to change the step of a request


### PR DESCRIPTION
## Summary
Adds several common LEAF URLs as constants to avoid using hard-coded values in test files.
Updates addQuestion utility to take options (for checkboxes, radio etc formats).
Adds utilities for form and request deletion, and email validation.

Updates recently refactored lifecycleNewRequest to use newly added URLs.
Significant refactor of adminPanelFormEditor to move out old 'helper' code and resolve a number of issues.

## Impact
Improve automated testing optimization and maintenance

## Testing
Tests associated with updated files should pass