### PR TITLE
Leaf 5074 - indicators in workflows

### DIFF
--- a/API-tests/formStack_test.go
+++ b/API-tests/formStack_test.go
@@ -37,6 +37,23 @@ func postNewForm() string {
 	return c
 }
 
+func postUpdateQuestion(indicator string, field string, format string) string {
+	postData := url.Values{}
+	postData.Set("CSRFToken", CsrfToken)
+	postData.Set(field, format)
+
+	res, _ := client.PostForm(RootURL+`api/formEditor/`+indicator+`/`+field, postData)
+	bodyBytes, _ := io.ReadAll(res.Body)
+
+	var c string
+	err := json.Unmarshal(bodyBytes, &c)
+	if err != nil {
+		log.Printf("JSON parsing error, couldn't parse: %v", string(c))
+	}
+
+	return c
+}
+
 func getFormStack(url string) FormStackResponse {
 	res, _ := client.Get(url)
 	b, _ := io.ReadAll(res.Body)
@@ -48,6 +65,27 @@ func getFormStack(url string) FormStackResponse {
 		log.Printf("JSON parsing error: %v", err.Error())
 	}
 	return m
+}
+
+func TestFormStack_UpdateFormat(t *testing.T) {
+	empUID := postUpdateQuestion("9", "format", "text")
+
+	got := empUID
+	want := "indicator used in workflow"
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Changing format return = %v, want = %v", got, want)
+	}
+
+	module := postUpdateQuestion("3", "disabled", "1")
+
+	got = module
+	want = "indicator used in workflow"
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("Archive or Delete return = %v, want = %v", got, want)
+	}
+
 }
 
 func TestFormStack_NewFormProperties(t *testing.T) {


### PR DESCRIPTION
## Summary
API test for 5038. This is a test to be sure that the correct message is returned in the api for updating format and archive and delete when they shouldn't be allowed to be updated.

## Impact
N/A 

## Testing
This is an API test so just run the API test.