### PR TITLE
LEAF 5064 - end2end test for LEAF 5038 INC40026543 - Form fields in workflows

### DIFF
--- a/end2end/tests/lifecycleFormEditor.spec.ts
+++ b/end2end/tests/lifecycleFormEditor.spec.ts
@@ -14,10 +14,10 @@ import {
 test.describe.configure({ mode: 'serial' });
 
 // Generate unique text to help ensure that fields are being filled correctly.
-let randNum = Math.random();
-let uniqueText = `New Form ${randNum}`;
-
 const testId = getRandomId();
+let uniqueText = `New Form ${testId}`;
+
+
 
 /**
  *  Create a new form with name in the variable 'uniqueText'
@@ -402,90 +402,113 @@ test.describe('Tests for LEAF 4697', () => {
  */
 test('Elements attached to a workflow cannot be deleted from form', async ({ page }) => {
 
-    // Create the form and add sections
-    const formEditorFieldsFormID = await createTestForm(page, `form_name_${testId}`, `form_descr_${testId}`);
-    const personSectionID = await addFormQuestion(page, 'Add Section', 'Assigned Person', 'Orgchart Employee');
-    const groupSectionID = await addFormQuestion(page, 'Add Section', 'Assigned Group', 'Orgchart Group');
-    const textSectionID = await addFormQuestion(page, 'Add Section', 'Single line text', 'Single line text');
+    let formEditorFieldsFormID = '';
+    let workflowID = '';
+    let stepID = '';
 
-    // Create workflow
     const workflowName = `workflow_name_${testId}`;
     const stepTitle = "Step 1";
-    const workflowAndStepIDs = await createBaseTestWorkflow(page, workflowName, stepTitle);
-    const workflowID = workflowAndStepIDs[0];
-    const stepID = workflowAndStepIDs[1];
-
-    // Attach workflow to form
-    await loadForm(page, formEditorFieldsFormID);
-    await page.getByLabel('Workflow: No Workflow. Users').selectOption(workflowID);
-
-    // Go back to the workflow
-    await loadWorkflow(page, workflowID);
     const stepElement = page.getByLabel(`workflow step: ${stepTitle}`, { exact: true });
-    await expect(stepElement).toBeVisible();
-    stepElement.click();
 
-    // Add Person designated requirement
-    const addRequirement = await page.getByRole('button', { name: 'Add Requirement' });
-    await expect(addRequirement).toBeVisible()
-    await addRequirement.click();
+    try {
+      // Create the form and add sections
+      formEditorFieldsFormID = await createTestForm(page, `form_name_${testId}`, `form_descr_${testId}`);
+      const personSectionID = await addFormQuestion(page, 'Add Section', 'Assigned Person', 'Orgchart Employee');
+      const groupSectionID = await addFormQuestion(page, 'Add Section', 'Assigned Group', 'Orgchart Group');
+      const textSectionID = await addFormQuestion(page, 'Add Section', 'Single line text', 'Single line text');
 
-    await selectChosenDropdownOption(page, '#dependencyID_chosen', 'Person Designated by the Requestor');
-    
-    const saveButton = await page.getByRole('button', { name: 'Save' });
-    saveButton.click();
+      // Create workflow
+      const workflowAndStepIDs = await createBaseTestWorkflow(page, workflowName, stepTitle);
+      workflowID = workflowAndStepIDs[0];
+      stepID = workflowAndStepIDs[1];
 
-    // Set the Available Person data field
-    const setDataField = await page.getByRole('button', { name: 'Set Data Field' });
-    await expect(setDataField).toBeVisible();
-    setDataField.click();
+      // Attach workflow to form
+      await loadForm(page, formEditorFieldsFormID);
+      await page.getByLabel('Workflow: No Workflow. Users').selectOption(workflowID);
 
-    await expect(page.getByText('Set Indicator ID')).toBeVisible();
-    await page.locator('#indicatorID').selectOption(personSectionID);
-    await saveButton.click();
-    await expect(stepElement).toBeVisible();
+      // Go back to the workflow
+      await loadWorkflow(page, workflowID);
+      await expect(stepElement).toBeVisible();
+      stepElement.click();
 
-    // Set the Single Line Text form field
-    await stepElement.click();
-    await page.getByLabel('Form Field:').selectOption(textSectionID);
-    await stepElement.click();
-    
-    // Confirm that the Input Form and Delete/Archive options are not available on Assigned Person
-    await loadForm(page, formEditorFieldsFormID);
-    await expect(page.getByText('Assigned Person')).toBeVisible();
-    await page.getByTitle('edit indicator ' + personSectionID).click();
-    await expect(page.locator('#input-format')).toContainText('This field is used in a workflow and must be removed from there before you can change its format.');
-    await expect(page.locator('#indicator-editing-attributes')).toContainText('This field is used in a workflow and must be removed from there before you can Archive or Delete it.');
-    await page.getByRole('button', { name: 'Cancel' }).click();
+      // Add Person designated requirement
+      const addRequirement = await page.getByRole('button', { name: 'Add Requirement' });
+      await expect(addRequirement).toBeVisible()
+      await addRequirement.click();
 
-    // Confirm the Archive and Delete are not available on the Single Line Text
-    await page.getByTitle('edit indicator ' + textSectionID).click();
-    await expect(page.locator('#indicator-editing-attributes')).toContainText('This field is used in a workflow and must be removed from there before you can Archive or Delete it.');
-    await page.getByRole('button', { name: 'Cancel' }).click();
+      await selectChosenDropdownOption(page, '#dependencyID_chosen', 'Person Designated by the Requestor');
+      
+      const saveButton = await page.getByRole('button', { name: 'Save' });
+      saveButton.click();
 
-    // Confirm the Archive/Delete and Input Dropdown are avaiable on the Assigned Group
-    await page.getByTitle('edit indicator ' + groupSectionID).click();
-    await expect(page.getByText('Input Format')).toBeVisible();
-    await expect(page.getByText('Archive', { exact: true })).toBeVisible();
-    await expect(page.getByText('Delete', { exact: true })).toBeVisible();
-    await page.getByRole('button', { name: 'Cancel' }).click();
+      // Set the Available Person data field
+      const setDataField = await page.getByRole('button', { name: 'Set Data Field' });
+      await expect(setDataField).toBeVisible();
+      setDataField.click();
 
-    // Delete the step from the workflow
-    await loadWorkflow(page, workflowID);
-    await expect(stepElement).toBeVisible();
-    stepElement.click();
+      await expect(page.getByText('Set Indicator ID')).toBeVisible();
+      await page.locator('#indicatorID').selectOption(personSectionID);
+      await saveButton.click();
+      await expect(stepElement).toBeVisible();
 
-    await expect(page.locator(`id=stepInfo_${stepID}`)).toBeVisible();
-    await page.getByLabel('Remove Step').click();
-    await page.getByRole('button', { name: 'Yes' }).click();
-    await expect(stepElement).not.toBeVisible();
+      // Set the Single Line Text form field
+      await stepElement.click();
+      await page.getByLabel('Form Field:').selectOption(textSectionID);
+      await stepElement.click();
+      
+      // Confirm that the Input Form and Delete/Archive options are not available on Assigned Person
+      await loadForm(page, formEditorFieldsFormID);
+      await expect(page.getByText('Assigned Person')).toBeVisible();
+      await page.getByTitle('edit indicator ' + personSectionID).click();
+      await expect(page.locator('#input-format')).toContainText('This field is used in a workflow and must be removed from there before you can change its format.');
+      await expect(page.locator('#indicator-editing-attributes')).toContainText('This field is used in a workflow and must be removed from there before you can Archive or Delete it.');
+      await page.getByRole('button', { name: 'Cancel' }).click();
 
-    // Delete the form
-    await deleteTestFormByFormID(page, formEditorFieldsFormID);
+      // Confirm the Archive and Delete are not available on the Single Line Text
+      await page.getByTitle('edit indicator ' + textSectionID).click();
+      await expect(page.locator('#indicator-editing-attributes')).toContainText('This field is used in a workflow and must be removed from there before you can Archive or Delete it.');
+      await page.getByRole('button', { name: 'Cancel' }).click();
 
-    // Delete the workflow
-    await loadWorkflow(page, workflowID);
-    await page.getByRole('button', { name: 'Delete Workflow' }).click();
-    await page.getByRole('button', { name: 'Yes' }).click();
+      // Confirm the Archive/Delete and Input Dropdown are avaiable on the Assigned Group
+      await page.getByTitle('edit indicator ' + groupSectionID).click();
+      await expect(page.getByText('Input Format')).toBeVisible();
+      await expect(page.getByText('Archive', { exact: true })).toBeVisible();
+      await expect(page.getByText('Delete', { exact: true })).toBeVisible();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+    } finally {
+
+      // Delete the work flow if it was created
+      if(workflowID != '') {
+        
+        await loadWorkflow(page, workflowID);
+
+        // Delete the step if it was created
+        if(stepID != '') {
+          
+          await expect(stepElement).toBeVisible();
+          stepElement.click();
+
+          await expect(page.locator(`id=stepInfo_${stepID}`)).toBeVisible();
+          await page.getByLabel('Remove Step').click();
+          await page.getByRole('button', { name: 'Yes' }).click();
+          await expect(stepElement).not.toBeVisible();
+        }
+      }
+      
+      if(formEditorFieldsFormID != '') {
+
+        // Delete the form
+        await deleteTestFormByFormID(page, formEditorFieldsFormID);
+      }
+
+      if(workflowID != '') {
+
+        // Delete the workflow
+        await loadWorkflow(page, workflowID);
+        await page.getByRole('button', { name: 'Delete Workflow' }).click();
+        await page.getByRole('button', { name: 'Yes' }).click();
+      }
+    }
     
 });


### PR DESCRIPTION
End2end test for LEAF 5038 which does the following:

1. Creates a form with 3 sections/questions - Assigned Person, Assigned Group, and Single Line Text
2. Creates a workflow linked to the above form with one step with the requirement 'Person Designated by the Requestor' and the data field of the Assigned Person. Also with the Form Field of Single Line Text.
3. Verifies that Assigned Person has messages for not changing the Input Format and Deleting/Archiving.
4. Verifies that Single Line Text has message indicating it cannot be Deleted or Archived.
5. Verified that Assigned Group has all features available. 
6. Once all the verifications are done the form and the workflow are deleted.

PR: https://github.com/department-of-veterans-affairs/LEAF/pull/2803