### PR TITLE
Leaf 5681 - added unsafe database name test

### DIFF
--- a/API-tests/platform_test.go
+++ b/API-tests/platform_test.go
@@ -39,3 +39,76 @@ func TestPlatform_getOrgchartTags(t *testing.T) {
 		t.Errorf("Test_Request_Portal was not found in orgchart ./api/platform/portal")
 	}
 }
+
+// this test verifies the platform endpoint only returns portals that have
+// SQL-safe portal_database values.
+func TestPlatform_getOrgchartTags_filtersUnsafePortalDatabases(t *testing.T) {
+	db := getDB()
+	defer db.Close()
+
+	_, err := db.Exec("USE national_leaf_launchpad")
+	if err != nil {
+		t.Fatalf("failed to switch to launchpad DB: %v", err)
+	}
+
+	validSitePath := "/LEAF_5681_SafePortal"
+	unsafeSitePath := "/LEAF_5681_UnsafePortal"
+
+	t.Cleanup(func() {
+		_, cleanupErr := db.Exec(
+			`DELETE FROM sites WHERE site_path IN (?, ?)`,
+			validSitePath,
+			unsafeSitePath,
+		)
+		if cleanupErr != nil {
+			t.Logf("cleanup warning: could not remove test sites: %v", cleanupErr)
+		}
+	})
+
+	_, err = db.Exec(
+		`INSERT INTO sites
+			(launchpadID, site_type, site_path, site_uploads, portal_database, orgchart_path, orgchart_database, decommissionTimestamp)
+		VALUES
+			(0, "portal", ?, "/var/www/html/LEAF_Request_Portal/UPLOADS_test", ?, "/Test_Nexus", ?, 0)`,
+		validSitePath,
+		testPortalDbName,
+		testNexusDbName,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert safe test portal: %v", err)
+	}
+
+	_, err = db.Exec(
+		`INSERT INTO sites
+			(launchpadID, site_type, site_path, site_uploads, portal_database, orgchart_path, orgchart_database, decommissionTimestamp)
+		VALUES
+			(0, "portal", ?, "/var/www/html/LEAF_Request_Portal/UPLOADS_test", ?, "/Test_Nexus", ?, 0)`,
+		unsafeSitePath,
+		"leaf_portal_API_testing;DROP_DATABASE",
+		testNexusDbName,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert unsafe test portal: %v", err)
+	}
+
+	portals := getOrgchartImportTags(RootOrgchartURL + `api/platform/portal`)
+
+	foundSafePortal := false
+	foundUnsafePortal := false
+	for _, portal := range portals {
+		if portal.Site_path == validSitePath {
+			foundSafePortal = true
+		}
+		if portal.Site_path == unsafeSitePath {
+			foundUnsafePortal = true
+		}
+	}
+
+	if !foundSafePortal {
+		t.Errorf("safe portal %s was unexpectedly filtered out", validSitePath)
+	}
+
+	if foundUnsafePortal {
+		t.Errorf("unsafe portal %s was unexpectedly returned by ./api/platform/portal", unsafeSitePath)
+	}
+}


### PR DESCRIPTION
## Summary
  This change adds an API test covering `./api/platform/portal` behavior when a portal record contains an unsafe `portal_database` value.

  The test inserts:
  - one valid portal record with a safe `portal_database`
  - one invalid portal record with an unsafe `portal_database`

  It then calls `getOrgchartImportTags(RootOrgchartURL + "api/platform/portal")` and asserts that:
  - the safe portal is returned
  - the unsafe portal is filtered out

  The test cleans up both inserted launchpad records after execution.

  ## Impact
  Impact should be limited to automated API test coverage in `API-tests/platform_test.go`. There is no intended runtime behavior change in this repo.

  ## Testing
  Automated coverage added here:
  `API-tests/platform_test.go`

  Validation:
  - Run the platform API test suite in the `API-tests` module
  - Confirm `TestPlatform_getOrgchartTags_filtersUnsafePortalDatabases` passes
  - Confirm the safe portal is present and the unsafe portal is excluded from the platform portal response