### PR TITLE
Form Editor Regression Tests

### DIFF
--- a/end2end/tests/regressionTests/FormEditor.spec.ts
+++ b/end2end/tests/regressionTests/FormEditor.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, Browser, Page} from '@playwright/test';
+import {
+  LEAF_URLS,
+  getRandomId,
+  createTestForm,
+  deleteTestFormByFormID,
+  addFormQuestion,
+  
+} from '../../leaf_test_utils/leaf_util_methods.ts';
+
+let page:Page;
+
+let formID = '';
+let testID = '';
+let formName = '';
+let formDescription = '';
+
+//set up a browser context that can be used to create a page in cleanup afterAll
+  test.beforeAll(async ({ browser }) => {
+
+    page = await browser.newPage();
+    testID = getRandomId();
+    formName = `Regression Form ${testID}`;
+    formDescription = formName + " Description";
+  });
+
+test('Create digital forms based on business process',{ tag: ['@LEAF-FM-001'] }, async () => {
+
+    // Create a new form
+  formID = await createTestForm(page, formName, formDescription);
+
+  // Add a new section
+  const sectionName = "Regression Section";
+  const sectionID = await addFormQuestion(page, "Add Section", sectionName);
+
+  // Add a question to the section
+  const primaryQuestion = "Supervisor Name";
+  const questionID = await addFormQuestion(page, "Add Question to Section", primaryQuestion, "Single line text");
+
+  // Add a sub-question to the above question 
+  const subQestion = 'Do we need their permission?';
+  await page.getByLabel('add sub-question').click();
+  await page.getByLabel('Field Name').fill(subQestion);
+
+  // Make the answers be Yes or No with radio buttons
+  const subOptions1 = 'Yes\nNo';
+
+  await page.getByLabel('Input Format').selectOption('radio');
+  await page.getByLabel('Options (One option per line)').fill(subOptions1);
+  
+  // Make the default answer be 'Yes"
+  const subDefault1 = 'Yes';
+
+  await page.getByLabel('Default Answer').fill(subDefault1);
+  await page.getByRole('button', { name: 'Save' }).click();
+  const subQuestionID = +questionID + 1;
+
+  // Verify the Yes radio button is selected
+  await expect(page.getByText(subDefault1)).toBeChecked();
+
+  // Change the primary question's input 
+  await page.getByTitle(`edit indicator ${questionID}`).click();
+  await page.getByLabel('Input Format').selectOption('orgchart_employee');
+
+  const primaryID = "#301";
+  const primaryName = 'Abbott, Hank Hessel.';
+
+  await page.getByLabel('search input').fill(primaryID);
+  await expect(page.getByRole('cell', { name: primaryName })).toBeVisible();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByRole('button', { name: 'Save' })).not.toBeVisible();
+  await expect(page.getByLabel('search input')).toHaveValue(primaryID);
+  await expect(page.getByRole('cell', { name: primaryName })).toBeVisible();
+
+  const subOption2 = "Yes";
+  const subDefault2 = "Yes";
+
+  await page.getByTitle(`edit indicator ${subQuestionID}`).click();
+  await page.getByLabel('Input Format').selectOption('checkbox');
+  await page.getByLabel('Text for checkbox').fill(subOption2);
+  await page.getByLabel('Default Answer').fill(subDefault2);
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText(subDefault2)).toBeChecked();
+});
+
+test.afterAll(async () => {
+
+  if(formID != '') {
+    await deleteTestFormByFormID(page, formID);
+  }
+});


### PR DESCRIPTION
## Summary
This PR covers the four regression tests for Form Editor: LEAF-FM-001, LEAF-FM-002, LEAF-FM-003, and LEAF-FM-004
Note: This branch was renamed to Form_Editor_Regression_Tests.

## Testing
The tests steps are the following:

**LEAF-FM-001**
1. Create a new form
2. Add a section with a new question that has a single line text
3. Ensure the question has been added
4. Add a sub-question with a radio button and default answer
5. Ensure the sub-question has been added and the default answer has been checked
6. Change the question to use an input type Org Chart Employee with a default value
7. Ensure the input type changed and the default value is set
8. Change the sub-question type to a checkbox with a default value
9. Ensure the input type has changed and the default value is checked

**LEAF-FM-002**
1. Load form created in previous test
2. Get the current timestamp
3. Reload the page (Playwright is too fast to just make the changes, the timestamp won't change)
4. Ensure the page has completely reloaded and the timestamp is visible again
5. From the workflow dropdown choose Workflow 1 and from the Status choose 'Available'
6. Get the new timestamp and compare it to the old timestamp.
7. Verify the new timestamp is greater than the old one
8. Go back to the form browser and verify the form is in the Active Forms table

**LEAF-FM-003**
1. Set the sub-question to Required
2. Verify the *Required is now next to the sub-question on the form
3. Create a new request using this form
4. Verify the *Required is next to the sub-question and it does not have a red background
5. Without answering the sub-question, click 'Next Question'
6. Verify the page didn't change and the *Required now has a red background
7. Answer the sub-question and click 'Next Question'
8. Confirm a new page was displayed

**LEAF-FM-004**
1. Add a condition to the sub-question where it will only display if a certain value is entered in the primary question
2. Create a new request using the form
3. When the primary question is displayed, verify the sub-question is not displayed
4. Select the answer which will display the sub-question
5. Verify the sub-question is displayed